### PR TITLE
fix: keyboard covers input

### DIFF
--- a/app.json
+++ b/app.json
@@ -32,7 +32,8 @@
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
-      }
+      },
+      "softwareKeyboardLayoutMode": "pan"
     }
   }
 }

--- a/components/pages/InvestScreen.tsx
+++ b/components/pages/InvestScreen.tsx
@@ -1,11 +1,11 @@
 import React, { useState, useRef } from 'react';
-import { View, Text, ScrollView, TextInput, TouchableOpacity, KeyboardAvoidingView, Platform } from 'react-native';
+import { View, Text, ScrollView, TextInput, TouchableOpacity } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
+import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 
 const InvestScreen = () => {
   const [depositAmount, setDepositAmount] = useState<string>('');
-  const scrollViewRef = useRef<ScrollView>(null);
 
   const formatCurrency = (value: string): string => {
     if (!value || value.trim() === '') {
@@ -34,7 +34,7 @@ const InvestScreen = () => {
 
     // Parse to number and format to 2 decimal places
     const numValue = parseFloat(filtered);
-    
+
     // Handle NaN case
     if (isNaN(numValue)) {
       return '0.00';
@@ -50,7 +50,7 @@ const InvestScreen = () => {
   const handleAmountChange = (text: string): void => {
     // Remove $ sign and spaces if present
     let filtered = text.replace(/[$\s,]/g, '');
-    
+
     // Filter out non-numeric characters except decimal point
     filtered = filtered.replace(/[^\d.]/g, '');
 
@@ -88,17 +88,17 @@ const InvestScreen = () => {
     if (!depositAmount || depositAmount === '') {
       return false;
     }
-    
+
     // Parse depositAmount to number
     const amount = parseFloat(depositAmount);
-    
+
     // Handle NaN or zero cases
     if (isNaN(amount) || amount === 0) {
       return false;
     }
-    
+
     // Check if amount is >= 10.00
-    return amount >= 10.00;
+    return amount >= 10.0;
   };
 
   // Handle deposit button press
@@ -108,170 +108,148 @@ const InvestScreen = () => {
 
   return (
     <SafeAreaView className="flex-1 bg-[#F5F5F5]" edges={['top']}>
-      <KeyboardAvoidingView 
-        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-        className="flex-1"
-        keyboardVerticalOffset={0}
-      >
-        <ScrollView 
-          ref={scrollViewRef}
-          className="bg-[#F5F5F5]"
-          keyboardShouldPersistTaps="handled"
-          contentContainerStyle={{ paddingBottom: 40 }}
-          showsVerticalScrollIndicator={false}
-        >
-        <View className="px-6 pt-6 pb-6">
-        {/* Page Title */}
-        <Text className="text-2xl font-bold text-[#343434] mb-6">
-          Invest in TrustUp
-        </Text>
+      <KeyboardAwareScrollView
+        enableOnAndroid
+        extraScrollHeight={80}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{
+          paddingBottom: 40,
+          flexGrow: 1,
+        }}>
+        <View className="px-6 pb-6 pt-6">
+          {/* Page Title */}
+          <Text className="mb-6 text-2xl font-bold text-[#343434]">Invest in TrustUp</Text>
 
-        {/* Investment Card */}
-        <View 
-          className="bg-white rounded-2xl p-6 mb-4 shadow-sm"
-          accessibilityRole="summary"
-          accessibilityLabel="Your investment summary"
-        >
-          <View className="flex-row items-center gap-2 mb-4">
-            <View className="w-10 h-10 bg-[#E9D5FF] rounded-full items-center justify-center">
-              <Ionicons name="trending-up" size={20} color="#9333EA" />
+          {/* Investment Card */}
+          <View
+            className="mb-4 rounded-2xl bg-white p-6 shadow-sm"
+            accessibilityRole="summary"
+            accessibilityLabel="Your investment summary">
+            <View className="mb-4 flex-row items-center gap-2">
+              <View className="h-10 w-10 items-center justify-center rounded-full bg-[#E9D5FF]">
+                <Ionicons name="trending-up" size={20} color="#9333EA" />
+              </View>
+              <Text className="text-base font-medium text-[#6B7280]">Your Investment</Text>
             </View>
-            <Text className="text-[#6B7280] font-medium text-base">Your Investment</Text>
-          </View>
-          
-          {/* Total Invested */}
-          <View className="mb-4">
-            <Text className="text-[#9CA3AF] text-sm mb-1">Total Invested</Text>
-            <Text className="text-5xl font-bold text-[#1F2937]">$1,250.00</Text>
-          </View>
 
-          {/* Earnings */}
-          <View className="flex-row justify-between items-center mb-2">
-            <Text className="text-[#9CA3AF] text-sm">Earnings</Text>
-            <Text className="text-base font-semibold text-[#10B981]">+$42.30</Text>
-          </View>
-
-          {/* Progress Line */}
-          <View className="h-1 bg-[#10B981] mb-4 rounded-full" />
-
-          {/* APY and Return Rate Row */}
-          <View className="flex-row justify-between items-start">
-            <View className="flex-1">
-              <Text className="text-[#9CA3AF] text-sm mb-1">Estimated APY</Text>
-              <Text className="text-3xl font-bold text-[#1F2937]">5.2%</Text>
+            {/* Total Invested */}
+            <View className="mb-4">
+              <Text className="mb-1 text-sm text-[#9CA3AF]">Total Invested</Text>
+              <Text className="text-5xl font-bold text-[#1F2937]">$1,250.00</Text>
             </View>
-            <View className="items-end">
-              <Text className="text-[#9CA3AF] text-sm mb-1">Return Rate</Text>
-              <Text className="text-base font-semibold text-[#10B981]">+3.4%</Text>
+
+            {/* Earnings */}
+            <View className="mb-2 flex-row items-center justify-between">
+              <Text className="text-sm text-[#9CA3AF]">Earnings</Text>
+              <Text className="text-base font-semibold text-[#10B981]">+$42.30</Text>
             </View>
-          </View>
-        </View>
-        
-        {/* Fund Overview Card */}
-        <View 
-          className="bg-white rounded-2xl p-6 mb-4 shadow-sm"
-          accessibilityRole="summary"
-          accessibilityLabel="Fund overview information"
-        >
-          <View className="flex-row items-center gap-2 mb-4">
-            <View className="w-10 h-10 bg-[#D1FAE5] rounded-full items-center justify-center">
-              <Text className="text-xl font-bold text-[#10B981]">$</Text>
-            </View>
-            <Text className="text-[#6B7280] font-medium text-base">Fund Overview</Text>
-          </View>
 
-          {/* Pool Size */}
-          <View className="flex-row justify-between items-center mb-3">
-            <Text className="text-[#9CA3AF] text-sm">Pool Size</Text>
-            <Text className="text-[#1F2937] font-semibold text-base">$48,320</Text>
-          </View>
+            {/* Progress Line */}
+            <View className="mb-4 h-1 rounded-full bg-[#10B981]" />
 
-          {/* Active Loans */}
-          <View className="flex-row justify-between items-center mb-3">
-            <Text className="text-[#9CA3AF] text-sm">Active Loans</Text>
-            <Text className="text-[#1F2937] font-semibold text-base">36</Text>
-          </View>
-
-          {/* Risk Level */}
-          <View className="flex-row justify-between items-center mb-3">
-            <Text className="text-[#9CA3AF] text-sm">Risk Level</Text>
-            <View className="bg-[#D1FAE5] px-3 py-1 rounded-full">
-              <Text className="text-[#10B981] text-xs font-semibold">Low</Text>
+            {/* APY and Return Rate Row */}
+            <View className="flex-row items-start justify-between">
+              <View className="flex-1">
+                <Text className="mb-1 text-sm text-[#9CA3AF]">Estimated APY</Text>
+                <Text className="text-3xl font-bold text-[#1F2937]">5.2%</Text>
+              </View>
+              <View className="items-end">
+                <Text className="mb-1 text-sm text-[#9CA3AF]">Return Rate</Text>
+                <Text className="text-base font-semibold text-[#10B981]">+3.4%</Text>
+              </View>
             </View>
           </View>
 
-          {/* Disclaimer Text */}
-          <Text className="text-[#9CA3AF] text-xs mt-1">
-            Returns depend on borrower behavior
-          </Text>
-        </View>
-        
-        {/* Deposit Card */}
-        <View className="bg-white rounded-2xl p-6 mb-4 shadow-sm">
-          <Text className="text-xl font-bold text-[#1F2937] mb-4">
-            Deposit Funds
-          </Text>
-          
-          {/* Amount Input Field */}
-          <View className="mb-4">
-            <Text className="text-[#9CA3AF] text-sm mb-2">
-              Amount to invest
+          {/* Fund Overview Card */}
+          <View
+            className="mb-4 rounded-2xl bg-white p-6 shadow-sm"
+            accessibilityRole="summary"
+            accessibilityLabel="Fund overview information">
+            <View className="mb-4 flex-row items-center gap-2">
+              <View className="h-10 w-10 items-center justify-center rounded-full bg-[#D1FAE5]">
+                <Text className="text-xl font-bold text-[#10B981]">$</Text>
+              </View>
+              <Text className="text-base font-medium text-[#6B7280]">Fund Overview</Text>
+            </View>
+
+            {/* Pool Size */}
+            <View className="mb-3 flex-row items-center justify-between">
+              <Text className="text-sm text-[#9CA3AF]">Pool Size</Text>
+              <Text className="text-base font-semibold text-[#1F2937]">$48,320</Text>
+            </View>
+
+            {/* Active Loans */}
+            <View className="mb-3 flex-row items-center justify-between">
+              <Text className="text-sm text-[#9CA3AF]">Active Loans</Text>
+              <Text className="text-base font-semibold text-[#1F2937]">36</Text>
+            </View>
+
+            {/* Risk Level */}
+            <View className="mb-3 flex-row items-center justify-between">
+              <Text className="text-sm text-[#9CA3AF]">Risk Level</Text>
+              <View className="rounded-full bg-[#D1FAE5] px-3 py-1">
+                <Text className="text-xs font-semibold text-[#10B981]">Low</Text>
+              </View>
+            </View>
+
+            {/* Disclaimer Text */}
+            <Text className="mt-1 text-xs text-[#9CA3AF]">Returns depend on borrower behavior</Text>
+          </View>
+
+          {/* Deposit Card */}
+          <View className="mb-4 rounded-2xl bg-white p-6 shadow-sm">
+            <Text className="mb-4 text-xl font-bold text-[#1F2937]">Deposit Funds</Text>
+
+            {/* Amount Input Field */}
+            <View className="mb-4">
+              <Text className="mb-2 text-sm text-[#9CA3AF]">Amount to invest</Text>
+              <TextInput
+                className="mb-2 text-5xl font-bold text-[#1F2937]"
+                keyboardType="numeric"
+                value={depositAmount ? `$${depositAmount}` : ''}
+                onChangeText={handleAmountChange}
+                placeholder="$0.00"
+                placeholderTextColor="#D1D5DB"
+                accessibilityLabel="Amount to invest input field"
+                accessibilityHint="Enter the amount you want to invest, minimum $10"
+              />
+              <Text className="text-xs text-[#9CA3AF]">Minimum deposit $10</Text>
+            </View>
+
+            {/* Deposit Button */}
+            <TouchableOpacity
+              className={`items-center rounded-2xl py-4 ${
+                isDepositValid() ? 'bg-[#FF9C42]' : 'bg-[#FF9C6E]'
+              }`}
+              onPress={handleDeposit}
+              disabled={!isDepositValid()}
+              accessibilityLabel="Deposit funds button"
+              accessibilityState={{ disabled: !isDepositValid() }}
+              accessibilityHint={!isDepositValid() ? 'Minimum $10 required' : undefined}>
+              <Text
+                className={`text-base font-semibold ${
+                  isDepositValid() ? 'text-white' : 'text-gray-200'
+                }`}>
+                Deposit funds
+              </Text>
+            </TouchableOpacity>
+          </View>
+
+          {/* Info Box */}
+          <View
+            className="flex-row items-start rounded-2xl bg-[#EFF6FF] p-4"
+            accessibilityRole="text"
+            accessibilityLabel="Important investment information">
+            <View className="mr-3 mt-0.5 h-6 w-6 items-center justify-center rounded-full bg-[#3B82F6]">
+              <Ionicons name="information" size={14} color="#FFFFFF" />
+            </View>
+            <Text className="flex-1 text-sm text-[#6B7280]">
+              Funds are used to finance BNPL purchases. Returns are not guaranteed.
             </Text>
-            <TextInput
-              className="text-5xl font-bold text-[#1F2937] mb-2"
-              keyboardType="numeric"
-              value={depositAmount ? `$${depositAmount}` : ''}
-              onChangeText={handleAmountChange}
-              onFocus={() => {
-                setTimeout(() => {
-                  scrollViewRef.current?.scrollTo({ y: 600, animated: true });
-                }, 150);
-              }}
-              placeholder="$0.00"
-              placeholderTextColor="#D1D5DB"
-              accessibilityLabel="Amount to invest input field"
-              accessibilityHint="Enter the amount you want to invest, minimum $10"
-            />
-            <Text className="text-[#9CA3AF] text-xs">
-              Minimum deposit $10
-            </Text>
           </View>
-          
-          {/* Deposit Button */}
-          <TouchableOpacity
-            className={`py-4 rounded-2xl items-center ${
-              isDepositValid() ? 'bg-[#FF9C42]' : 'bg-[#FF9C6E]'
-            }`}
-            onPress={handleDeposit}
-            disabled={!isDepositValid()}
-            accessibilityLabel="Deposit funds button"
-            accessibilityState={{ disabled: !isDepositValid() }}
-            accessibilityHint={!isDepositValid() ? "Minimum $10 required" : undefined}
-          >
-            <Text className={`font-semibold text-base ${
-              isDepositValid() ? 'text-white' : 'text-gray-200'
-            }`}>
-              Deposit funds
-            </Text>
-          </TouchableOpacity>
         </View>
-        
-        {/* Info Box */}
-        <View 
-          className="bg-[#EFF6FF] rounded-2xl p-4 flex-row items-start"
-          accessibilityRole="text"
-          accessibilityLabel="Important investment information"
-        >
-          <View className="w-6 h-6 bg-[#3B82F6] rounded-full items-center justify-center mr-3 mt-0.5">
-            <Ionicons name="information" size={14} color="#FFFFFF" />
-          </View>
-          <Text className="text-[#6B7280] text-sm flex-1">
-            Funds are used to finance BNPL purchases. Returns are not guaranteed.
-          </Text>
-        </View>
-      </View>
-    </ScrollView>
-      </KeyboardAvoidingView>
+      </KeyboardAwareScrollView>
     </SafeAreaView>
   );
 };

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.5",
+    "react-native-keyboard-aware-scroll-view": "^0.9.5",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-svg": "^15.15.1",


### PR DESCRIPTION
## 🔗 Related Issue
Closes https://github.com/TrustUp-app/TrustUp-Frontend/issues/12
---

## 🔖 Fix InvestScreen: keyboard covers "Deposit Funds" card and amount input

---

## 📝 Description

It was tested with several options, natively, but it is not 100% compatible with Android devices.
The conclusion was reached to use the react-native-keyboard-aware-scroll-view package to maintain compatibility across all Android devices.

---

## 🔄 Changes Made
<!-- List the main changes in this PR -->
✅ add react-native-keyboard-aware-scroll-view package
✅ configuration for Android in app.json
✅ refactor in the InvestScreen component

---

## 📸 Screenshots (if applicable)

https://github.com/user-attachments/assets/41a4377b-1e66-43eb-add1-f8e8c2e2e98b


https://github.com/user-attachments/assets/747be6c5-ef57-439a-b17a-34690bddb143



---

## 🗒️ Additional Notes
<!-- Any additional information, concerns, or context for reviewers -->
