### PR TITLE
refactor: extract SignInScreen logic into useSignIn hook

### DIFF
--- a/components/pages/SignIn.tsx
+++ b/components/pages/SignIn.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import {
   StyleSheet,
   View,
@@ -11,21 +11,17 @@ import {
   ScrollView,
 } from 'react-native';
 import { User, Lock, Eye, EyeOff, Wallet, ArrowRight } from 'lucide-react-native';
+import { useSignIn } from '../../hooks/auth/use-sign-in';
 
 export default function SignInScreen() {
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
-  const [secureText, setSecureText] = useState(true);
-  const [isValid, setIsValid] = useState(false);
-
-  // Form Validation Logic
-  useEffect(() => {
-    setIsValid(username.trim().length > 0 && password.trim().length > 0);
-  }, [username, password]);
-
-  const handleSignIn = () => {
-    console.log('Form Data:', { username, password });
-  };
+  const {
+    formState,
+    isValid,
+    handleUsernameChange,
+    handlePasswordChange,
+    toggleSecureText,
+    handleSignIn,
+  } = useSignIn();
 
   return (
     <KeyboardAvoidingView
@@ -50,8 +46,8 @@ export default function SignInScreen() {
               style={styles.input}
               placeholder="@josue_crypto"
               placeholderTextColor="#cbd5e1"
-              value={username}
-              onChangeText={setUsername}
+              value={formState.username}
+              onChangeText={handleUsernameChange}
               autoCapitalize="none"
             />
           </View>
@@ -63,12 +59,12 @@ export default function SignInScreen() {
               style={styles.input}
               placeholder="••••••••"
               placeholderTextColor="#cbd5e1"
-              value={password}
-              onChangeText={setPassword}
-              secureTextEntry={secureText}
+              value={formState.password}
+              onChangeText={handlePasswordChange}
+              secureTextEntry={formState.secureText}
             />
-            <TouchableOpacity onPress={() => setSecureText(!secureText)}>
-              {secureText ? (
+            <TouchableOpacity onPress={toggleSecureText}>
+              {formState.secureText ? (
                 <Eye stroke="#94a3b8" size={20} />
               ) : (
                 <EyeOff stroke="#94a3b8" size={20} />

--- a/hooks/auth/use-sign-in.ts
+++ b/hooks/auth/use-sign-in.ts
@@ -1,0 +1,90 @@
+import { useState, useCallback, useEffect } from 'react';
+
+/**
+ * Form field state for the sign in form
+ */
+export interface SignInFormState {
+  username: string;
+  password: string;
+  secureText: boolean;
+}
+
+/**
+ * Return type for the useSignIn hook
+ */
+export interface UseSignInReturn {
+  // Form state
+  formState: SignInFormState;
+  isValid: boolean;
+
+  // Field handlers
+  handleUsernameChange: (text: string) => void;
+  handlePasswordChange: (text: string) => void;
+  toggleSecureText: () => void;
+
+  // Actions
+  handleSignIn: () => void;
+}
+
+/**
+ * Initial form state
+ */
+const initialFormState: SignInFormState = {
+  username: '',
+  password: '',
+  secureText: true,
+};
+
+/**
+ * Validates if the sign in form is valid
+ * Both username and password must be non-empty
+ */
+export const validateSignInForm = (username: string, password: string): boolean => {
+  return username.trim().length > 0 && password.trim().length > 0;
+};
+
+/**
+ * Custom hook for Sign In functionality
+ * Handles all form state, validation, and sign in logic
+ */
+export const useSignIn = (): UseSignInReturn => {
+  const [formState, setFormState] = useState<SignInFormState>(initialFormState);
+  const [isValid, setIsValid] = useState(false);
+
+  // Form Validation Logic
+  useEffect(() => {
+    setIsValid(validateSignInForm(formState.username, formState.password));
+  }, [formState.username, formState.password]);
+
+  // Field change handlers
+  const handleUsernameChange = useCallback((text: string) => {
+    setFormState((prev) => ({ ...prev, username: text }));
+  }, []);
+
+  const handlePasswordChange = useCallback((text: string) => {
+    setFormState((prev) => ({ ...prev, password: text }));
+  }, []);
+
+  const toggleSecureText = useCallback(() => {
+    setFormState((prev) => ({ ...prev, secureText: !prev.secureText }));
+  }, []);
+
+  // Sign in handler
+  const handleSignIn = useCallback(() => {
+    console.log('Form Data:', { username: formState.username, password: formState.password });
+  }, [formState.username, formState.password]);
+
+  return {
+    // Form state
+    formState,
+    isValid,
+
+    // Field handlers
+    handleUsernameChange,
+    handlePasswordChange,
+    toggleSecureText,
+
+    // Actions
+    handleSignIn,
+  };
+};


### PR DESCRIPTION
I created a dedicated useSignIn hook under /hooks/auth to separate business logic from UI. I moved form state, validation, and handlers into the hook following existing patterns. I kept the SignInScreen purely presentational with no behavior changes.

## 🔗 Related Issue
Closes #6

---

## 🔖 Title
Refactor Sign In page logic into dedicated auth hook ([/hooks/auth](cci:9://file:///home/maziofweb3/cds/dripsRpos/TrustUp-Frontend/hooks/auth:0:0-0:0))

---

## 📝 Description
This PR refactors the SignInScreen page to move its business logic and state management into a dedicated custom hook under the [/hooks/auth](cci:9://file:///home/maziofweb3/cds/dripsRpos/TrustUp-Frontend/hooks/auth:0:0-0:0) directory. The screen component is now purely presentational and declarative. This improves reusability, testability, and readability by separating concerns between UI and business logic.

---

## 🔄 Changes Made
- [x] Created [hooks/auth/use-sign-in.ts](cci:7://file:///home/maziofweb3/cds/dripsRpos/TrustUp-Frontend/hooks/auth/use-sign-in.ts:0:0-0:0) with [SignInFormState](cci:2://file:///home/maziofweb3/cds/dripsRpos/TrustUp-Frontend/hooks/auth/use-sign-in.ts:5:0-9:1) and [UseSignInReturn](cci:2://file:///home/maziofweb3/cds/dripsRpos/TrustUp-Frontend/hooks/auth/use-sign-in.ts:14:0-26:1) interfaces
- [x] Moved form state (`username`, `password`, `secureText`, `isValid`) into the hook
- [x] Moved validation logic and handlers (`handleSignIn`, `toggleSecureText`) into the hook
- [x] Updated `SignInScreen.tsx` to consume the [useSignIn()](cci:1://file:///home/maziofweb3/cds/dripsRpos/TrustUp-Frontend/hooks/auth/use-sign-in.ts:45:0-89:2) hook
- [x] Exported pure [validateSignInForm](cci:1://file:///home/maziofweb3/cds/dripsRpos/TrustUp-Frontend/hooks/auth/use-sign-in.ts:37:0-43:2) helper for testability

---

## 📸 Screenshots (if applicable)
N/A - No visual changes. This is a refactor-only task with no UI/UX modifications.

---

## 🗒️ Additional Notes
- Follows existing hook patterns from [use-create-account.ts](cci:7://file:///home/maziofweb3/cds/dripsRpos/TrustUp-Frontend/hooks/auth/use-create-account.ts:0:0-0:0) and [use-invest.ts](cci:7://file:///home/maziofweb3/cds/dripsRpos/TrustUp-Frontend/hooks/invest/use-invest.ts:0:0-0:0)
- TypeScript compiles with no errors
- Lint passes with no new warnings
- The UI and behavior of the Sign In flow remain unchanged