### PR TITLE
feat: add Settings screen and wire Header settings icon

### DIFF
--- a/components/pages/SettingsScreen.tsx
+++ b/components/pages/SettingsScreen.tsx
@@ -1,0 +1,176 @@
+import React from 'react';
+import {
+  View,
+  Text,
+  ScrollView,
+  TouchableOpacity,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
+const colors = require('../../theme/colors.json');
+
+interface SettingsRowProps {
+  icon: React.ComponentProps<typeof Ionicons>['name'];
+  iconBg: string;
+  iconColor: string;
+  label: string;
+  subtitle: string;
+}
+
+const SettingsRow = ({ icon, iconBg, iconColor, label, subtitle }: SettingsRowProps) => (
+  <TouchableOpacity
+    activeOpacity={0.7}
+    className="flex-row items-center px-4 py-3"
+    accessibilityRole="button"
+    accessibilityLabel={label}>
+    <View
+      className="mr-3 h-9 w-9 items-center justify-center rounded-full"
+      style={{ backgroundColor: iconBg }}>
+      <Ionicons name={icon} size={18} color={iconColor} />
+    </View>
+    <View className="flex-1">
+      <Text className="text-sm font-semibold text-text">{label}</Text>
+      <Text className="text-xs text-textMuted">{subtitle}</Text>
+    </View>
+    <Ionicons name="chevron-forward" size={16} color={colors.textMuted} />
+  </TouchableOpacity>
+);
+
+type SettingsSectionProps = React.PropsWithChildren<{
+  title: string;
+}>;
+
+const SettingsSection = ({ title, children }: SettingsSectionProps) => (
+  <View className="mb-5">
+    <Text className="mb-2 px-1 text-xs font-semibold uppercase tracking-widest text-textMuted">
+      {title}
+    </Text>
+    <View className="overflow-hidden rounded-2xl bg-white shadow-sm">
+      {children}
+    </View>
+  </View>
+);
+
+interface SettingsScreenProps {
+  onClose: () => void;
+}
+
+const SettingsScreen = ({ onClose }: SettingsScreenProps) => {
+  return (
+    <SafeAreaView className="flex-1 bg-background" edges={['top']}>
+      {/* Header */}
+      <View className="flex-row items-center bg-white px-4 pb-4 pt-4">
+        <TouchableOpacity
+          activeOpacity={0.7}
+          onPress={onClose}
+          className="mr-3 h-9 w-9 items-center justify-center rounded-full bg-gray-100"
+          accessibilityRole="button"
+          accessibilityLabel="Go back">
+          <Ionicons name="chevron-back" size={20} color={colors.text} />
+        </TouchableOpacity>
+        <Text className="text-xl font-semibold text-text">Settings</Text>
+      </View>
+
+      <ScrollView
+        className="flex-1 px-4 pt-5"
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{ paddingBottom: 40 }}>
+
+        {/* ACCOUNT */}
+        <SettingsSection title="Account">
+          <SettingsRow
+            icon="person-outline"
+            iconBg={colors.primarySoft}
+            iconColor={colors.primary}
+            label="Profile"
+            subtitle="Manage your personal information"
+          />
+          <View className="mx-4 h-px bg-border" />
+          <SettingsRow
+            icon="mail-outline"
+            iconBg={colors.primarySoft}
+            iconColor={colors.primary}
+            label="Email"
+            subtitle="Change your email address"
+          />
+          <View className="mx-4 h-px bg-border" />
+          <SettingsRow
+            icon="call-outline"
+            iconBg={colors.primarySoft}
+            iconColor={colors.primary}
+            label="Phone Number"
+            subtitle="Update your contact number"
+          />
+        </SettingsSection>
+
+        {/* PREFERENCES */}
+        <SettingsSection title="Preferences">
+          <SettingsRow
+            icon="sunny-outline"
+            iconBg={colors.amberSoft}
+            iconColor={colors.amber}
+            label="Dark Mode"
+            subtitle="Switch between light and dark theme"
+          />
+          <View className="mx-4 h-px bg-border" />
+          <SettingsRow
+            icon="notifications-outline"
+            iconBg={colors.primarySoft}
+            iconColor={colors.primary}
+            label="Notifications"
+            subtitle="Receive push notifications"
+          />
+          <View className="mx-4 h-px bg-border" />
+          <SettingsRow
+            icon="finger-print-outline"
+            iconBg={colors.successSoft}
+            iconColor={colors.successDeep}
+            label="Biometric Authentication"
+            subtitle="Use fingerprint or face ID"
+          />
+        </SettingsSection>
+
+        {/* PAYMENT */}
+        <SettingsSection title="Payment">
+          <SettingsRow
+            icon="card-outline"
+            iconBg={colors.amberSoft}
+            iconColor={colors.amber}
+            label="Payment Methods"
+            subtitle="Manage your cards and accounts"
+          />
+          <View className="mx-4 h-px bg-border" />
+          <SettingsRow
+            icon="lock-closed-outline"
+            iconBg={colors.primarySoft}
+            iconColor={colors.primary}
+            label="Auto Pay"
+            subtitle="Automatically pay your loans"
+          />
+        </SettingsSection>
+
+        {/* SUPPORT */}
+        <SettingsSection title="Support">
+          <SettingsRow
+            icon="help-circle-outline"
+            iconBg={colors.infoSoft}
+            iconColor={colors.info}
+            label="Help & Support"
+            subtitle="Get help with your account"
+          />
+          <View className="mx-4 h-px bg-border" />
+          <SettingsRow
+            icon="shield-outline"
+            iconBg={colors.successSoft}
+            iconColor={colors.successDeep}
+            label="Privacy Policy"
+            subtitle="Read our privacy policy"
+          />
+        </SettingsSection>
+
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+export default SettingsScreen;

--- a/components/shared/Header.tsx
+++ b/components/shared/Header.tsx
@@ -6,9 +6,10 @@ const colors = require('../../theme/colors.json');
 
 interface HeaderProps {
   onNotificationsPress?: () => void;
+  onSettingsPress?: () => void;
 }
 
-export const Header = ({ onNotificationsPress }: HeaderProps) => {
+export const Header = ({ onNotificationsPress, onSettingsPress }: HeaderProps) => {
   return (
     <View className="bg-white px-6 pb-4 pt-12">
       <View className="flex-row items-center justify-between">
@@ -18,7 +19,12 @@ export const Header = ({ onNotificationsPress }: HeaderProps) => {
         {/* Right icon */}
         <View className="flex-row items-center gap-4">
           {/* Settings icon */}
-          <TouchableOpacity activeOpacity={0.7} className="h-10 w-10 items-center justify-center">
+          <TouchableOpacity
+            activeOpacity={0.7}
+            className="h-10 w-10 items-center justify-center"
+            onPress={onSettingsPress}
+            accessibilityRole="button"
+            accessibilityLabel="Open settings">
             <Ionicons name="settings-outline" size={24} color={colors.text} />
           </TouchableOpacity>
 

--- a/components/shared/MainLayout.tsx
+++ b/components/shared/MainLayout.tsx
@@ -1,10 +1,11 @@
-import { View, ScrollView, SafeAreaView, StyleSheet, KeyboardAvoidingView, Platform } from 'react-native';
+import { View, ScrollView, SafeAreaView, StyleSheet, KeyboardAvoidingView, Platform, Modal } from 'react-native';
 
 import { ReactNode, useState } from 'react';
 
 import { BottomBar } from './BottomBar';
 import { Header } from './Header';
 import { NotificationsPanel } from './NotificationsPanel';
+import SettingsScreen from '../pages/SettingsScreen';
 // Centralized color palette shared with Tailwind
 const colors = require('../../theme/colors.json');
 
@@ -15,6 +16,7 @@ interface MainLayoutProps {
 export const MainLayout = ({ children }: MainLayoutProps) => {
   const [activeTab, setActiveTab] = useState('home');
   const [isNotificationsOpen, setIsNotificationsOpen] = useState(false);
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
 
   return (
     <SafeAreaView style={styles.safeArea}>
@@ -24,7 +26,10 @@ export const MainLayout = ({ children }: MainLayoutProps) => {
         keyboardVerticalOffset={60}
       >
         <View style={styles.container}>
-          <Header onNotificationsPress={() => setIsNotificationsOpen(true)} />
+          <Header
+            onNotificationsPress={() => setIsNotificationsOpen(true)}
+            onSettingsPress={() => setIsSettingsOpen(true)}
+          />
           <ScrollView
             contentContainerStyle={styles.content}
             style={styles.flex}
@@ -42,6 +47,15 @@ export const MainLayout = ({ children }: MainLayoutProps) => {
           isOpen={isNotificationsOpen}
           onClose={() => setIsNotificationsOpen(false)}
         />
+
+        {/* Settings Screen Modal */}
+        <Modal
+          visible={isSettingsOpen}
+          animationType="slide"
+          presentationStyle="pageSheet"
+          onRequestClose={() => setIsSettingsOpen(false)}>
+          <SettingsScreen onClose={() => setIsSettingsOpen(false)} />
+        </Modal>
       </KeyboardAvoidingView>
     </SafeAreaView>
   );


### PR DESCRIPTION
- Create components/pages/SettingsScreen.tsx with visual-only layout (Account, Preferences, Payment, Support sections with placeholder rows)
- Add onSettingsPress prop to Header component
- Wire settings icon TouchableOpacity to open Settings via Modal in MainLayout
- Follows NativeWind/Tailwind styling and project conventions

## 🔗 Related Issue
Closes #issue-number

---

## 🔖 Title
<!-- Brief and clear. Describe the specific task -->

---

## 📝 Description
<!-- Describe the changes made in this PR. What problem does it solve? -->

---

## 🔄 Changes Made
<!-- List the main changes in this PR -->
- [ ] <!-- Change 1 -->
- [ ] <!-- Change 2 -->
- [ ] <!-- Change 3 -->

---

## 📸 Screenshots (if applicable)
<!-- Add screenshots or GIFs if the changes affect the UI -->

---

## 🗒️ Additional Notes
<!-- Any additional information, concerns, or context for reviewers -->
