### PR TITLE
fix: hide global header and bottom navigation when settings is open

### DIFF
--- a/components/shared/MainLayout.tsx
+++ b/components/shared/MainLayout.tsx
@@ -22,10 +22,12 @@ export const MainLayout = ({ children }: MainLayoutProps) => {
         keyboardVerticalOffset={60}
       >
         <View className="flex-1 pb-[60px]">
-          <Header
-            onNotificationsPress={() => setIsNotificationsOpen(true)}
-            onSettingsPress={() => setIsSettingsOpen(true)}
-          />
+          {!isSettingsOpen && (
+            <Header
+              onNotificationsPress={() => setIsNotificationsOpen(true)}
+              onSettingsPress={() => setIsSettingsOpen(true)}
+            />
+          )}
           <ScrollView
             contentContainerClassName="flex-grow"
             className="flex-1"
@@ -34,9 +36,11 @@ export const MainLayout = ({ children }: MainLayoutProps) => {
             {children}
           </ScrollView>
         </View>
-        <View className="absolute left-0 right-0 bottom-0 h-[60px] bg-transparent z-10">
-          <BottomBar activeTab={activeTab} setActiveTab={setActiveTab} />
-        </View>
+        {!isSettingsOpen && (
+          <View className="absolute left-0 right-0 bottom-0 h-[60px] bg-transparent z-10">
+            <BottomBar activeTab={activeTab} setActiveTab={setActiveTab} />
+          </View>
+        )}
 
         {/* Settings Overlay */}
         {isSettingsOpen && (


### PR DESCRIPTION
closes #35
---
## 🔗 Related Issue
Closes #35

---

## 🔖 Title
Hide global header and bottom navigation while SettingsScreen is open

---

## 📝 Description
This PR fixes a UI inconsistency where the global Header and BottomBar remained visible when the SettingsScreen was opened as an overlay.

The change ensures that when the settings view is active, both the Header and BottomBar are hidden, providing a proper full-screen experience. When the user exits the settings screen, both elements are restored exactly as before without affecting layout or navigation behavior.

This implementation is scoped strictly to visibility control and does not introduce any changes to navigation flow, UI structure, or existing component logic.

---

## 🔄 Changes Made
- [x] Updated `MainLayout` to conditionally hide `Header` when `isSettingsOpen === true`
- [x] Updated `MainLayout` to conditionally hide `BottomBar` when `isSettingsOpen === true`
- [x] Ensured `SettingsScreen` `onBack` restores both elements correctly
- [x] Preserved existing layout structure and state management
- [x] Verified no TypeScript or linting issues introduced

---

## 📸 Screenshots 

### Settings Screen (Full-screen view without Header & BottomBar)

![Uploading Screenshot (162).png…]()



---

## 🗒️ Additional Notes
- No changes were made to settings UI design, navigation flow, or unrelated components
- Notifications panel behavior remains unchanged
- No unnecessary use of `any` introduced
- Manual testing confirms:
  - Header and BottomBar are hidden when settings opens
  - Both are restored correctly when settings closes
  - No layout shift or flicker occurs

![Uploading Screenshot (162).png…]()
