### PR TITLE
fix(TrustUp-Frontend): fix-nativewind-color-palette-broken-colors-json-

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
-    "name": "my-expo-app",
-    "slug": "my-expo-app",
+    "name": "TrustUp",
+    "slug": "trustup",
     "version": "1.0.0",
     "web": {
       "favicon": "./assets/favicon.png"

--- a/components/Container.tsx
+++ b/components/Container.tsx
@@ -1,9 +1,5 @@
-import { SafeAreaView } from 'react-native';
+import { View } from 'react-native';
 
 export const Container = ({ children }: { children: React.ReactNode }) => {
-  return <SafeAreaView className={styles.container}>{children}</SafeAreaView>;
-};
-
-const styles = {
-  container: 'flex flex-1 m-6',
+  return <View className="flex-1 bg-white">{children}</View>;
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,12 +1,12 @@
-import { transform } from '@babel/core';
-import { opacity } from 'react-native-reanimated/lib/typescript/Colors';
-import keyframes from 'react-native-reanimated/lib/typescript/css/stylesheet/keyframes';
-
 /** @type {import('tailwindcss').Config} */
 const appColors = require('./theme/colors.json');
 
 module.exports = {
-  content: ['./App.{js,ts,tsx}', './components/**/*.{js,ts,tsx}'],
+  content: [
+    './App.{js,ts,tsx}',
+    './components/**/*.{js,ts,tsx}',
+    './hooks/**/*.{js,ts,tsx}',
+  ],
   darkMode: 'class',
   presets: [require('nativewind/preset')],
   theme: {


### PR DESCRIPTION
Closes #56

## Summary
- fix: NativeWind color palette broken — colors.json never registered in tailwind.config.js

## Test plan
- [ ] Relevant tests pass locally
- [ ] Manual verification on affected UI or API paths