### PR TITLE
Implement Merchant Discovery screen (list + detail view)

### DIFF
--- a/components/pages/MerchantDetailScreen.tsx
+++ b/components/pages/MerchantDetailScreen.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, ScrollView, ActivityIndicator, Image } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
+import { useMerchantDetail } from '../../hooks/merchants/use-merchant-detail';
+import type { MerchantSummary } from '../../types/api';
+
+const colors = require('../../theme/colors.json');
+
+const formatDate = (dateStr: string): string => {
+  const date = new Date(dateStr);
+  if (Number.isNaN(date.getTime())) return '—';
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+};
+
+const DetailRow = ({ label, value }: { label: string; value: string }) => (
+  <View className="flex-row items-center justify-between border-b border-borderSubtle py-3">
+    <Text className="text-sm text-textMuted">{label}</Text>
+    <Text className="text-sm font-medium text-textStrong" numberOfLines={1}>
+      {value}
+    </Text>
+  </View>
+);
+
+interface MerchantDetailScreenProps {
+  merchant: MerchantSummary;
+  onBack: () => void;
+  onStartPurchasePress: (merchant: MerchantSummary) => void;
+}
+
+const MerchantDetailScreen: React.FC<MerchantDetailScreenProps> = ({
+  merchant,
+  onBack,
+  onStartPurchasePress,
+}) => {
+  const insets = useSafeAreaInsets();
+  const { merchant: detail, isLoading, error, refresh } = useMerchantDetail(merchant.id);
+
+  const logo = detail?.logo || merchant.logo;
+  const category = detail?.category || merchant.category;
+
+  return (
+    <View style={{ flex: 1, backgroundColor: colors.background }}>
+      {/* Header */}
+      <View
+        style={{
+          backgroundColor: colors.white,
+          paddingHorizontal: 16,
+          paddingTop: insets.top + 16,
+          paddingBottom: 16,
+        }}>
+        <View className="flex-row items-center gap-3">
+          <TouchableOpacity
+            onPress={onBack}
+            activeOpacity={0.7}
+            accessibilityLabel="Go back"
+            accessibilityRole="button"
+            className="h-10 w-10 items-center justify-center rounded-full border border-border bg-white">
+            <Ionicons name="chevron-back" size={20} color={colors.text} />
+          </TouchableOpacity>
+          <Text className="flex-1 text-xl font-bold text-text" numberOfLines={1}>
+            {merchant.name}
+          </Text>
+          {merchant.isActive && (
+            <View className="rounded-full bg-successSoft px-3 py-1">
+              <Text className="text-xs font-semibold text-successDeep">Active</Text>
+            </View>
+          )}
+        </View>
+      </View>
+
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={{ padding: 16, paddingBottom: 120 }}
+        showsVerticalScrollIndicator={false}>
+        {/* Error banner */}
+        {error && (
+          <View className="mb-3 flex-row items-center gap-2 rounded-xl bg-errorSoft px-4 py-3">
+            <Ionicons name="alert-circle" size={18} color={colors.error} />
+            <Text className="flex-1 text-sm text-error">{error}</Text>
+            <TouchableOpacity onPress={refresh}>
+              <Text className="text-sm font-semibold text-error">Retry</Text>
+            </TouchableOpacity>
+          </View>
+        )}
+
+        {/* Summary Card */}
+        <View className="mb-4 items-center rounded-2xl bg-white p-6 shadow-sm">
+          <View className="mb-3 h-20 w-20 items-center justify-center overflow-hidden rounded-2xl bg-primarySoft">
+            {logo ? (
+              <Image source={{ uri: logo }} className="h-full w-full" resizeMode="cover" />
+            ) : (
+              <Ionicons name="storefront-outline" size={36} color={colors.primary} />
+            )}
+          </View>
+          <Text className="text-lg font-bold text-text">{merchant.name}</Text>
+          {category && <Text className="mt-1 text-sm text-textMuted">{category}</Text>}
+        </View>
+
+        {/* Description */}
+        {detail?.description && (
+          <View className="mb-4 rounded-2xl bg-white p-6 shadow-sm">
+            <Text className="mb-2 text-base font-bold text-textStrong">About</Text>
+            <Text className="text-sm leading-5 text-textSecondary">{detail.description}</Text>
+          </View>
+        )}
+
+        {/* Loading indicator while enriching with detail-only fields */}
+        {isLoading && !detail && (
+          <View className="items-center py-6">
+            <ActivityIndicator size="small" color={colors.primary} />
+          </View>
+        )}
+
+        {/* Merchant Details */}
+        <View className="rounded-2xl bg-white p-6 shadow-sm">
+          <Text className="mb-3 text-base font-bold text-textStrong">Merchant Details</Text>
+          <DetailRow label="Wallet" value={merchant.wallet} />
+          {category && <DetailRow label="Category" value={category} />}
+          {detail?.website && <DetailRow label="Website" value={detail.website} />}
+          <DetailRow label="Status" value={merchant.isActive ? 'Active' : 'Inactive'} />
+          {detail?.createdAt && (
+            <DetailRow label="Member since" value={formatDate(detail.createdAt)} />
+          )}
+        </View>
+      </ScrollView>
+
+      {/* Fixed CTA at bottom */}
+      <View
+        className="absolute bottom-0 left-0 right-0 border-t border-border bg-white px-6 pb-2 pt-4"
+        style={{ paddingBottom: Math.max(insets.bottom, 16) }}>
+        <TouchableOpacity
+          activeOpacity={0.8}
+          className="items-center rounded-xl bg-cta py-4"
+          onPress={() => onStartPurchasePress(merchant)}
+          accessibilityLabel="Start BNPL purchase"
+          accessibilityRole="button">
+          <View className="flex-row items-center gap-2">
+            <Text className="text-base font-semibold text-white">Start BNPL Purchase</Text>
+            <Ionicons name="arrow-forward" size={18} color="white" />
+          </View>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+};
+
+export default MerchantDetailScreen;

--- a/components/pages/MerchantsScreen.tsx
+++ b/components/pages/MerchantsScreen.tsx
@@ -1,5 +1,15 @@
 import React from 'react';
-import { View, Text, TouchableOpacity, ScrollView, ActivityIndicator, Image } from 'react-native';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  ScrollView,
+  ActivityIndicator,
+  Image,
+  NativeSyntheticEvent,
+  NativeScrollEvent,
+} from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { useMerchants } from '../../hooks/merchants/use-merchants';
@@ -9,9 +19,18 @@ const colors = require('../../theme/colors.json');
 
 // ─── Sub-components ─────────────────────────────────────────────────────────
 
-const MerchantCard = ({ merchant }: { merchant: MerchantSummary }) => (
-  <View
+const MerchantCard = ({
+  merchant,
+  onPress,
+}: {
+  merchant: MerchantSummary;
+  onPress: (merchant: MerchantSummary) => void;
+}) => (
+  <TouchableOpacity
+    activeOpacity={0.7}
+    onPress={() => onPress(merchant)}
     className="mb-3 flex-row items-center gap-3 rounded-2xl bg-white p-4 shadow-sm"
+    accessibilityRole="button"
     accessibilityLabel={`${merchant.name}, ${merchant.category}`}>
     <View className="h-12 w-12 items-center justify-center overflow-hidden rounded-xl bg-primarySoft">
       {merchant.logo ? (
@@ -31,18 +50,35 @@ const MerchantCard = ({ merchant }: { merchant: MerchantSummary }) => (
         <Text className="text-xs font-semibold text-successDeep">Active</Text>
       </View>
     )}
+    <Ionicons name="chevron-forward" size={18} color={colors.textSubtle} />
+  </TouchableOpacity>
+);
+
+const MerchantCardSkeleton = () => (
+  <View className="mb-3 flex-row items-center gap-3 rounded-2xl bg-white p-4 shadow-sm">
+    <View className="h-12 w-12 rounded-xl bg-gray-100" />
+    <View className="flex-1 gap-2">
+      <View className="h-3.5 w-2/3 rounded-full bg-gray-100" />
+      <View className="h-3 w-1/3 rounded-full bg-gray-100" />
+    </View>
   </View>
 );
 
-const ComingSoonState = () => (
+const EmptyState = ({
+  icon,
+  title,
+  description,
+}: {
+  icon: keyof typeof Ionicons.glyphMap;
+  title: string;
+  description: string;
+}) => (
   <View className="flex-1 items-center justify-center px-8 pt-24">
     <View className="mb-4 h-16 w-16 items-center justify-center rounded-full bg-gray-100">
-      <Ionicons name="storefront-outline" size={32} color={colors.textSubtle} />
+      <Ionicons name={icon} size={32} color={colors.textSubtle} />
     </View>
-    <Text className="mb-1 text-base font-semibold text-text">Merchants coming soon</Text>
-    <Text className="text-center text-sm leading-5 text-textSecondary">
-      We&apos;re onboarding merchants that accept Buy Now, Pay Later.{'\n'}Check back shortly.
-    </Text>
+    <Text className="mb-1 text-base font-semibold text-text">{title}</Text>
+    <Text className="text-center text-sm leading-5 text-textSecondary">{description}</Text>
   </View>
 );
 
@@ -50,13 +86,26 @@ const ComingSoonState = () => (
 
 interface MerchantsScreenProps {
   onBack: () => void;
+  onMerchantPress: (merchant: MerchantSummary) => void;
 }
 
-const MerchantsScreen: React.FC<MerchantsScreenProps> = ({ onBack }) => {
+const MerchantsScreen: React.FC<MerchantsScreenProps> = ({ onBack, onMerchantPress }) => {
   const insets = useSafeAreaInsets();
-  const { merchants, isLoading, error, refresh } = useMerchants();
+  const { merchants, isLoading, error, hasMore, query, setQuery, loadMore, refresh } =
+    useMerchants();
 
-  const showComingSoon = !isLoading && !error && merchants.length === 0;
+  const isInitialLoad = isLoading && merchants.length === 0;
+  const showEmpty = !isLoading && !error && merchants.length === 0;
+
+  const handleScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    const { layoutMeasurement, contentOffset, contentSize } = event.nativeEvent;
+    const distanceFromBottom = contentSize.height - layoutMeasurement.height - contentOffset.y;
+
+    // Load more when user scrolls within 100px of the bottom
+    if (distanceFromBottom < 100 && hasMore && !isLoading) {
+      loadMore();
+    }
+  };
 
   return (
     <View style={{ flex: 1, backgroundColor: colors.background }}>
@@ -68,7 +117,7 @@ const MerchantsScreen: React.FC<MerchantsScreenProps> = ({ onBack }) => {
           paddingTop: insets.top + 16,
           paddingBottom: 16,
         }}>
-        <View className="flex-row items-center gap-3">
+        <View className="mb-4 flex-row items-center gap-3">
           <TouchableOpacity
             onPress={onBack}
             activeOpacity={0.7}
@@ -79,12 +128,37 @@ const MerchantsScreen: React.FC<MerchantsScreenProps> = ({ onBack }) => {
           </TouchableOpacity>
           <Text className="text-xl font-bold text-text">Merchants</Text>
         </View>
+
+        {/* Search bar */}
+        <View className="flex-row items-center gap-2 rounded-xl border border-border bg-background px-3 py-2.5">
+          <Ionicons name="search" size={18} color={colors.textSubtle} />
+          <TextInput
+            value={query}
+            onChangeText={setQuery}
+            placeholder="Search merchants"
+            placeholderTextColor={colors.placeholder}
+            className="flex-1 text-sm text-text"
+            accessibilityLabel="Search merchants by name"
+            autoCapitalize="none"
+            autoCorrect={false}
+          />
+          {query.length > 0 && (
+            <TouchableOpacity
+              onPress={() => setQuery('')}
+              accessibilityLabel="Clear search"
+              accessibilityRole="button">
+              <Ionicons name="close-circle" size={18} color={colors.textSubtle} />
+            </TouchableOpacity>
+          )}
+        </View>
       </View>
 
       <ScrollView
         className="flex-1"
         contentContainerStyle={{ padding: 16, paddingBottom: 40 }}
-        showsVerticalScrollIndicator={false}>
+        showsVerticalScrollIndicator={false}
+        onScroll={handleScroll}
+        scrollEventThrottle={400}>
         {/* Error banner */}
         {error && (
           <View className="mb-3 flex-row items-center gap-2 rounded-xl bg-errorSoft px-4 py-3">
@@ -96,20 +170,40 @@ const MerchantsScreen: React.FC<MerchantsScreenProps> = ({ onBack }) => {
           </View>
         )}
 
-        {/* Merchant list */}
-        {merchants.map((merchant) => (
-          <MerchantCard key={merchant.id} merchant={merchant} />
-        ))}
+        {/* Loading skeleton (initial load) */}
+        {isInitialLoad && Array.from({ length: 6 }).map((_, i) => <MerchantCardSkeleton key={i} />)}
 
-        {/* Loading */}
-        {isLoading && (
+        {/* Merchant list */}
+        {!isInitialLoad &&
+          merchants.map((merchant) => (
+            <MerchantCard key={merchant.id} merchant={merchant} onPress={onMerchantPress} />
+          ))}
+
+        {/* Load-more spinner */}
+        {isLoading && !isInitialLoad && (
           <View className="items-center py-6">
             <ActivityIndicator size="small" color={colors.primary} />
           </View>
         )}
 
-        {/* Coming soon / empty */}
-        {showComingSoon && <ComingSoonState />}
+        {/* Empty states */}
+        {showEmpty && query.trim() ? (
+          <EmptyState
+            icon="search-outline"
+            title="No merchants found"
+            description={`No merchants match "${query.trim()}". Try a different search.`}
+          />
+        ) : (
+          showEmpty && (
+            <EmptyState
+              icon="storefront-outline"
+              title="Merchants coming soon"
+              description={
+                "We're onboarding merchants that accept Buy Now, Pay Later.\nCheck back shortly."
+              }
+            />
+          )
+        )}
       </ScrollView>
     </View>
   );

--- a/components/shared/MainLayout.tsx
+++ b/components/shared/MainLayout.tsx
@@ -9,6 +9,9 @@ import LoanHistoryScreen from '../pages/LoanHistoryScreen';
 import LoanDetailScreen from '../pages/LoanDetailScreen';
 import ReputationScreen from '../pages/ReputationScreen';
 import MerchantsScreen from '../pages/MerchantsScreen';
+import ProfileScreen from '../pages/ProfileScreen';
+import EditProfileScreen from '../pages/EditProfileScreen';
+import { useProfile, getInitials } from '../../hooks/profile/use-profile';
 import type { Loan } from '../../types/Loan';
 
 interface MainLayoutProps {
@@ -33,6 +36,8 @@ export const MainLayout = ({ children, onSignOut }: MainLayoutProps) => {
   const [isLoanDetailOpen, setIsLoanDetailOpen] = useState(false);
   const [isReputationOpen, setIsReputationOpen] = useState(false);
   const [isMerchantsOpen, setIsMerchantsOpen] = useState(false);
+  const [isProfileOpen, setIsProfileOpen] = useState(false);
+  const [isEditProfileOpen, setIsEditProfileOpen] = useState(false);
   const [selectedLoan, setSelectedLoan] = useState<Loan | null>(null);
   const [toastMessage, setToastMessage] = useState<string | null>(null);
 
@@ -63,7 +68,13 @@ export const MainLayout = ({ children, onSignOut }: MainLayoutProps) => {
 
   // Any full-screen overlay hides the header/bottom bar
   const hasOverlay =
-    isSettingsOpen || isLoanHistoryOpen || isLoanDetailOpen || isReputationOpen || isMerchantsOpen;
+    isSettingsOpen ||
+    isLoanHistoryOpen ||
+    isLoanDetailOpen ||
+    isReputationOpen ||
+    isMerchantsOpen ||
+    isProfileOpen ||
+    isEditProfileOpen;
 
   // Inject callbacks into children so PayScreen can trigger navigation
   const enhancedChildren = isValidElement(children)

--- a/components/shared/MainLayout.tsx
+++ b/components/shared/MainLayout.tsx
@@ -9,10 +9,12 @@ import LoanHistoryScreen from '../pages/LoanHistoryScreen';
 import LoanDetailScreen from '../pages/LoanDetailScreen';
 import ReputationScreen from '../pages/ReputationScreen';
 import MerchantsScreen from '../pages/MerchantsScreen';
+import MerchantDetailScreen from '../pages/MerchantDetailScreen';
 import ProfileScreen from '../pages/ProfileScreen';
 import EditProfileScreen from '../pages/EditProfileScreen';
 import { useProfile, getInitials } from '../../hooks/profile/use-profile';
 import type { Loan } from '../../types/Loan';
+import type { MerchantSummary } from '../../types/api';
 
 interface MainLayoutProps {
   children: ReactNode;
@@ -36,9 +38,11 @@ export const MainLayout = ({ children, onSignOut }: MainLayoutProps) => {
   const [isLoanDetailOpen, setIsLoanDetailOpen] = useState(false);
   const [isReputationOpen, setIsReputationOpen] = useState(false);
   const [isMerchantsOpen, setIsMerchantsOpen] = useState(false);
+  const [isMerchantDetailOpen, setIsMerchantDetailOpen] = useState(false);
   const [isProfileOpen, setIsProfileOpen] = useState(false);
   const [isEditProfileOpen, setIsEditProfileOpen] = useState(false);
   const [selectedLoan, setSelectedLoan] = useState<Loan | null>(null);
+  const [selectedMerchant, setSelectedMerchant] = useState<MerchantSummary | null>(null);
   const [toastMessage, setToastMessage] = useState<string | null>(null);
 
   const { profile, isLoading, error, disconnectWallet, saveProfile } = useProfile();
@@ -51,6 +55,25 @@ export const MainLayout = ({ children, onSignOut }: MainLayoutProps) => {
   const handleLoanDetailBack = () => {
     setIsLoanDetailOpen(false);
     setSelectedLoan(null);
+  };
+
+  const handleMerchantPress = (merchant: MerchantSummary) => {
+    setSelectedMerchant(merchant);
+    setIsMerchantDetailOpen(true);
+  };
+
+  const handleMerchantDetailBack = () => {
+    setIsMerchantDetailOpen(false);
+    setSelectedMerchant(null);
+  };
+
+  // No dedicated loan-application screen exists yet — return to the base
+  // screen (where the BNPL purchase flow lives) and confirm the selection.
+  const handleStartPurchase = (merchant: MerchantSummary) => {
+    setIsMerchantDetailOpen(false);
+    setIsMerchantsOpen(false);
+    setSelectedMerchant(null);
+    setToastMessage(`Selected ${merchant.name} — continue your BNPL purchase below`);
   };
 
   const handleDisconnect = async () => {
@@ -73,6 +96,7 @@ export const MainLayout = ({ children, onSignOut }: MainLayoutProps) => {
     isLoanDetailOpen ||
     isReputationOpen ||
     isMerchantsOpen ||
+    isMerchantDetailOpen ||
     isProfileOpen ||
     isEditProfileOpen;
 
@@ -184,7 +208,21 @@ export const MainLayout = ({ children, onSignOut }: MainLayoutProps) => {
         {/* Merchants Overlay */}
         {isMerchantsOpen && (
           <View className="absolute inset-0 z-20">
-            <MerchantsScreen onBack={() => setIsMerchantsOpen(false)} />
+            <MerchantsScreen
+              onBack={() => setIsMerchantsOpen(false)}
+              onMerchantPress={handleMerchantPress}
+            />
+          </View>
+        )}
+
+        {/* Merchant Detail Overlay */}
+        {isMerchantDetailOpen && selectedMerchant && (
+          <View className="absolute inset-0 z-30">
+            <MerchantDetailScreen
+              merchant={selectedMerchant}
+              onBack={handleMerchantDetailBack}
+              onStartPurchasePress={handleStartPurchase}
+            />
           </View>
         )}
 

--- a/hooks/merchants/use-merchant-detail.ts
+++ b/hooks/merchants/use-merchant-detail.ts
@@ -1,0 +1,53 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { getMerchantById } from '../../services/merchants.service';
+import { ApiClientError } from '../../lib/api-client';
+import type { MerchantDetail } from '../../types/api';
+
+export interface UseMerchantDetailReturn {
+  merchant: MerchantDetail | null;
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => void;
+}
+
+/**
+ * Custom hook backing the Merchant Detail screen.
+ * `GET /merchants/:id` (JWT).
+ */
+export const useMerchantDetail = (merchantId: string): UseMerchantDetailReturn => {
+  const [merchant, setMerchant] = useState<MerchantDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  const isMountedRef = useRef(true);
+  const refresh = useCallback(() => setReloadKey((k) => k + 1), []);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    const controller = new AbortController();
+    const { signal } = controller;
+
+    (async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const res = await getMerchantById(merchantId, signal);
+        if (!isMountedRef.current || signal.aborted) return;
+        setMerchant(res);
+      } catch (err) {
+        if (signal.aborted || !isMountedRef.current) return;
+        setError(err instanceof ApiClientError ? err.message : 'Failed to load merchant');
+      } finally {
+        if (isMountedRef.current && !signal.aborted) setIsLoading(false);
+      }
+    })();
+
+    return () => {
+      isMountedRef.current = false;
+      controller.abort();
+    };
+  }, [merchantId, reloadKey]);
+
+  return { merchant, isLoading, error, refresh };
+};

--- a/hooks/merchants/use-merchants.ts
+++ b/hooks/merchants/use-merchants.ts
@@ -3,52 +3,83 @@ import { listMerchants } from '../../services/merchants.service';
 import { ApiClientError } from '../../lib/api-client';
 import type { MerchantSummary } from '../../types/api';
 
+const PAGE_SIZE = 20;
+
 export interface UseMerchantsReturn {
   merchants: MerchantSummary[];
   isLoading: boolean;
   error: string | null;
+  hasMore: boolean;
+  query: string;
+  setQuery: (query: string) => void;
+  loadMore: () => void;
   refresh: () => void;
 }
 
 /**
  * Custom hook backing the Merchants listing screen.
- * `GET /merchants` (JWT). When the list is empty (or the endpoint is not yet
- * available) the screen shows a "coming soon" state.
+ * Paginates `GET /merchants?limit=20&offset=N` (JWT). The backend has no
+ * search parameter, so `query` filters by name over the merchants loaded
+ * so far — scrolling further (`loadMore`) still fetches more candidates.
  */
 export const useMerchants = (): UseMerchantsReturn => {
-  const [merchants, setMerchants] = useState<MerchantSummary[]>([]);
+  const [rawMerchants, setRawMerchants] = useState<MerchantSummary[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(false);
+  const [query, setQuery] = useState('');
   const [reloadKey, setReloadKey] = useState(0);
 
   const isMountedRef = useRef(true);
-  const refresh = useCallback(() => setReloadKey((k) => k + 1), []);
+  const offsetRef = useRef(0);
+  const controllerRef = useRef<AbortController | null>(null);
+
+  const fetchPage = useCallback(async (pageOffset: number, append: boolean) => {
+    controllerRef.current?.abort();
+    const controller = new AbortController();
+    controllerRef.current = controller;
+
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await listMerchants({
+        limit: PAGE_SIZE,
+        offset: pageOffset,
+        signal: controller.signal,
+      });
+      if (!isMountedRef.current || controller.signal.aborted) return;
+      setRawMerchants((prev) => (append ? [...prev, ...res.merchants] : res.merchants));
+      offsetRef.current = pageOffset + res.merchants.length;
+      setHasMore(pageOffset + res.merchants.length < res.total);
+    } catch (err) {
+      if (controller.signal.aborted || !isMountedRef.current) return;
+      setError(err instanceof ApiClientError ? err.message : 'Failed to load merchants');
+    } finally {
+      if (isMountedRef.current && !controller.signal.aborted) setIsLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
     isMountedRef.current = true;
-    const controller = new AbortController();
-    const { signal } = controller;
-
-    (async () => {
-      setIsLoading(true);
-      setError(null);
-      try {
-        const res = await listMerchants({ signal });
-        if (!isMountedRef.current || signal.aborted) return;
-        setMerchants(res.merchants);
-      } catch (err) {
-        if (signal.aborted || !isMountedRef.current) return;
-        setError(err instanceof ApiClientError ? err.message : 'Failed to load merchants');
-      } finally {
-        if (isMountedRef.current && !signal.aborted) setIsLoading(false);
-      }
-    })();
-
+    offsetRef.current = 0;
+    fetchPage(0, false);
     return () => {
       isMountedRef.current = false;
-      controller.abort();
+      controllerRef.current?.abort();
     };
-  }, [reloadKey]);
+  }, [fetchPage, reloadKey]);
 
-  return { merchants, isLoading, error, refresh };
+  const loadMore = useCallback(() => {
+    if (isLoading || !hasMore) return;
+    fetchPage(offsetRef.current, true);
+  }, [isLoading, hasMore, fetchPage]);
+
+  const refresh = useCallback(() => setReloadKey((k) => k + 1), []);
+
+  const trimmedQuery = query.trim().toLowerCase();
+  const merchants = trimmedQuery
+    ? rawMerchants.filter((m) => m.name.toLowerCase().includes(trimmedQuery))
+    : rawMerchants;
+
+  return { merchants, isLoading, error, hasMore, query, setQuery, loadMore, refresh };
 };

--- a/services/merchants.service.ts
+++ b/services/merchants.service.ts
@@ -1,5 +1,5 @@
-import { apiClient, isApiConfigured } from '../lib/api-client';
-import type { MerchantListResponse, MerchantSummary } from '../types/api';
+import { apiClient, ApiClientError, isApiConfigured } from '../lib/api-client';
+import type { MerchantDetail, MerchantListResponse, MerchantSummary } from '../types/api';
 
 /**
  * Dev seed used ONLY when no API base URL is configured. Shaped to the real
@@ -52,4 +52,54 @@ export async function listMerchants({
     return { merchants: DEV_MERCHANTS, total: DEV_MERCHANTS.length, limit, offset };
   }
   return apiClient.get<MerchantListResponse>('/merchants', { params: { limit, offset }, signal });
+}
+
+/** Dev seed for `getMerchantById`, keyed by the `DEV_MERCHANTS` ids above. */
+const DEV_MERCHANT_DETAILS: Record<string, MerchantDetail> = {
+  'merchant-1': {
+    id: 'merchant-1',
+    wallet: 'GMER...ABC',
+    name: 'TechStore',
+    logo: '',
+    description: 'Electronics retailer accepting BNPL purchases through TrustUp.',
+    category: 'Electronics',
+    website: 'https://techstore.example.com',
+    isActive: true,
+    createdAt: '2026-01-01T00:00:00.000Z',
+  },
+  'merchant-2': {
+    id: 'merchant-2',
+    wallet: 'GMER...DEF',
+    name: 'FashionHub',
+    logo: '',
+    description: 'Clothing and accessories retailer accepting BNPL purchases through TrustUp.',
+    category: 'Fashion',
+    website: 'https://fashionhub.example.com',
+    isActive: true,
+    createdAt: '2026-01-01T00:00:00.000Z',
+  },
+  'merchant-3': {
+    id: 'merchant-3',
+    wallet: 'GMER...GHI',
+    name: 'HomeGoods',
+    logo: '',
+    description: 'Home and living goods retailer accepting BNPL purchases through TrustUp.',
+    category: 'Home & Living',
+    website: 'https://homegoods.example.com',
+    isActive: true,
+    createdAt: '2026-01-01T00:00:00.000Z',
+  },
+};
+
+/**
+ * `GET /merchants/:id` — merchant details (JWT). Note the backend returns the
+ * payload directly (no `{ success, data }` envelope).
+ */
+export async function getMerchantById(id: string, signal?: AbortSignal): Promise<MerchantDetail> {
+  if (!isApiConfigured) {
+    const merchant = DEV_MERCHANT_DETAILS[id];
+    if (!merchant) throw new ApiClientError('Merchant not found', 404);
+    return merchant;
+  }
+  return apiClient.get<MerchantDetail>(`/merchants/${id}`, { signal });
 }

--- a/types/api.ts
+++ b/types/api.ts
@@ -125,3 +125,17 @@ export interface MerchantListResponse {
   limit: number;
   offset: number;
 }
+
+/** `GET /merchants/:id` → returned directly (no success envelope). */
+export interface MerchantDetail {
+  id: string;
+  wallet: string;
+  name: string;
+  logo: string;
+  description?: string;
+  category?: string;
+  website?: string;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt?: string;
+}


### PR DESCRIPTION
## 🔗 Related Issue
Closes #51

---

## 🔖 Title
Implement Merchant Discovery screen (list + detail view)

---

## 📝 Description
The `PayScreen` had an "Explore Merchants" button that did nothing. This PR adds a full Merchant Discovery flow: a paginated/searchable merchant list and a merchant detail screen, both backed by `GET /merchants` and `GET /merchants/:id` (JWT-protected, via the existing `apiClient`).

The response shapes were verified against the real `TrustUp-API` source (`src/modules/merchants/*`), not just the issue description — the backend field is `wallet` (not `walletAddress`), and the summary DTO also includes `logo`/`category`.

A separate first commit (`fix(main-layout): ...`) fixes an unrelated pre-existing bug: a prior merge had dropped `ProfileScreen`/`EditProfileScreen`/`useProfile` imports and state from `MainLayout.tsx` while leaving the JSX that referenced them, so `main` currently fails `tsc` (13 errors) and can't render at all. I needed the app compiling to test this feature, so I fixed it in its own isolated commit — happy to split it into a separate PR if preferred.

---

## 🔄 Changes Made
- [x] `types/api.ts` — add `MerchantDetail` type (`GET /merchants/:id` contract)
- [x] `services/merchants.service.ts` — add `getMerchantById` (dev-seed-gated like the rest of the service, same pattern as `listMerchants`)
- [x] `hooks/merchants/use-merchants.ts` — add offset-based pagination (`hasMore`/`loadMore`) and name search (client-side — the backend has no search query param)
- [x] `hooks/merchants/use-merchant-detail.ts` — new hook backing the detail screen
- [x] `components/pages/MerchantsScreen.tsx` — search bar, pressable cards, infinite scroll, loading skeleton, and two distinct empty states ("no merchants at all" vs "no results for this search")
- [x] `components/pages/MerchantDetailScreen.tsx` — new screen: summary, description/website/member-since (once loaded), "Start BNPL Purchase" CTA
- [x] `components/shared/MainLayout.tsx` — registers the new detail overlay (`selectedMerchant`/`isMerchantDetailOpen`), mirroring the existing Loan History → Loan Detail master-detail pattern
- [x] `components/shared/MainLayout.tsx` (separate commit) — fix pre-existing broken Profile/EditProfile wiring blocking compilation

---

## 📸 Screenshots (if applicable)
Verified visually (headless browser + a real Android device via Expo Go) rather than attached here — see test plan below for exact steps if you'd like to reproduce.

https://github.com/user-attachments/assets/3983815f-f380-4071-9ca7-a2e8c303daea

---

## 🗒️ Additional Notes

**Assumptions/limitations reviewers should know about:**
1. **Search is client-side.** `GET /merchants` only supports `limit`/`offset` (confirmed against the real backend DTO), so the search bar filters merchants already loaded rather than querying the server. Scrolling further still fetches more pages via `loadMore`.
2. **No loan-application screen exists yet** anywhere in the codebase (no quote/create-loan endpoints wired either), so "Start BNPL Purchase" can't hand off to one. It currently closes the merchant screens, returns to `PayScreen`, and shows a confirmation toast — a placeholder until that flow is built.
3. **Navigation** uses the app's existing bespoke overlay pattern in `MainLayout.tsx` (not `@react-navigation`, which is an unused dependency in this repo), for consistency with every other screen (Loan History/Detail, Reputation, Settings, etc.).

**Test plan:**
- `npx tsc --noEmit` — clean
- `eslint` / `prettier -c` on all changed files — clean (repo-wide `prettier -c` currently flags ~58 pre-existing files unrelated to this PR, appears to be a line-ending/environment issue, not something introduced here)
- Manual (web, headless via Playwright): full flow — Explore → list loads → search filters (both matches and "no results") → tap merchant → detail loads and enriches with description/website/member-since → "Start BNPL Purchase" → returns to PayScreen with toast → back button navigation. No console errors.
- Manual (physical Android device via Expo Go over LAN): same flow re-verified by hand.
- To reproduce locally: no `EXPO_PUBLIC_API_URL` needed (dev seeds kick in automatically). `PayScreen` isn't currently mounted by `App.tsx` (`InvestScreen` is, pre-existing/unrelated) and sign-in requires a live backend with no dev fallback, so reviewers will need to temporarily swap `<InvestScreen />` for `<PayScreen />` in `App.tsx` and bypass the session gate to reach the "Explore Merchants" entry point — happy to elaborate if useful for review.