### PR TITLE
feat-notifications-panel

### DIFF
--- a/components/shared/Header.tsx
+++ b/components/shared/Header.tsx
@@ -8,6 +8,7 @@ interface HeaderProps {
   displayName?: string;
   avatarUrl?: string | null;
   initials?: string;
+  unreadNotificationsCount?: number;
   onNotificationsPress?: () => void;
   onSettingsPress?: () => void;
   onProfilePress?: () => void;
@@ -28,6 +29,7 @@ export const Header = ({
   displayName,
   avatarUrl,
   initials,
+  unreadNotificationsCount = 0,
   onNotificationsPress,
   onSettingsPress,
   onProfilePress,
@@ -60,8 +62,17 @@ export const Header = ({
           <TouchableOpacity
             activeOpacity={0.7}
             className="h-10 w-10 items-center justify-center"
-            onPress={onNotificationsPress}>
+            onPress={onNotificationsPress}
+            accessibilityLabel="Open Notifications"
+            accessibilityRole="button">
             <Ionicons name="notifications-outline" size={24} color={colors.text} />
+            {unreadNotificationsCount > 0 && (
+              <View className="absolute right-1 top-1 h-4 min-w-[16px] items-center justify-center rounded-full bg-red-500 px-1">
+                <Text className="text-[10px] font-bold text-white">
+                  {unreadNotificationsCount > 99 ? '99+' : unreadNotificationsCount}
+                </Text>
+              </View>
+            )}
           </TouchableOpacity>
 
           {/* Avatar */}

--- a/components/shared/MainLayout.tsx
+++ b/components/shared/MainLayout.tsx
@@ -9,6 +9,10 @@ import LoanHistoryScreen from '../pages/LoanHistoryScreen';
 import LoanDetailScreen from '../pages/LoanDetailScreen';
 import ReputationScreen from '../pages/ReputationScreen';
 import MerchantsScreen from '../pages/MerchantsScreen';
+import ProfileScreen from '../pages/ProfileScreen';
+import EditProfileScreen from '../pages/EditProfileScreen';
+import { useProfile, getInitials } from '../../hooks/profile/use-profile';
+import { useNotifications } from '../../hooks/notifications/use-notifications';
 import type { Loan } from '../../types/Loan';
 
 interface MainLayoutProps {
@@ -33,10 +37,13 @@ export const MainLayout = ({ children, onSignOut }: MainLayoutProps) => {
   const [isLoanDetailOpen, setIsLoanDetailOpen] = useState(false);
   const [isReputationOpen, setIsReputationOpen] = useState(false);
   const [isMerchantsOpen, setIsMerchantsOpen] = useState(false);
+  const [isProfileOpen, setIsProfileOpen] = useState(false);
+  const [isEditProfileOpen, setIsEditProfileOpen] = useState(false);
   const [selectedLoan, setSelectedLoan] = useState<Loan | null>(null);
   const [toastMessage, setToastMessage] = useState<string | null>(null);
 
   const { profile, isLoading, error, disconnectWallet, saveProfile } = useProfile();
+  const { unreadCount } = useNotifications();
 
   const handleLoanPress = (loan: Loan) => {
     setSelectedLoan(loan);
@@ -87,6 +94,7 @@ export const MainLayout = ({ children, onSignOut }: MainLayoutProps) => {
               displayName={profile?.displayName}
               avatarUrl={profile?.avatarUrl}
               initials={profile ? getInitials(profile.displayName) : undefined}
+              unreadNotificationsCount={unreadCount}
               onNotificationsPress={() => setIsNotificationsOpen(true)}
               onSettingsPress={() => setIsSettingsOpen(true)}
               onProfilePress={() => setIsProfileOpen(true)}

--- a/components/shared/MainLayout.tsx
+++ b/components/shared/MainLayout.tsx
@@ -10,6 +10,7 @@ import LoanHistoryScreen from '../pages/LoanHistoryScreen';
 import LoanDetailScreen from '../pages/LoanDetailScreen';
 import ReputationScreen from '../pages/ReputationScreen';
 import MerchantsScreen from '../pages/MerchantsScreen';
+import MerchantDetailScreen from '../pages/MerchantDetailScreen';
 import ProfileScreen from '../pages/ProfileScreen';
 import EditProfileScreen from '../pages/EditProfileScreen';
 import { useProfile, getInitials } from '../../hooks/profile/use-profile';

--- a/components/shared/NotificationsPanel.tsx
+++ b/components/shared/NotificationsPanel.tsx
@@ -14,69 +14,18 @@ import Animated, {
   useAnimatedStyle,
   withTiming,
   Easing,
+  runOnJS,
 } from 'react-native-reanimated';
 import { Ionicons } from '@expo/vector-icons';
 
 import { BlurView } from 'expo-blur';
+import { useNotifications } from '../../hooks/notifications/use-notifications';
+import type { NotificationType } from '../../types/Notification';
 
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
 const PANEL_WIDTH = SCREEN_WIDTH * 0.88;
 
 const colors = require('../../theme/colors.json');
-
-type NotificationType = 'payment' | 'credit' | 'merchant' | 'reputation' | 'security';
-
-interface Notification {
-  id: string;
-  type: NotificationType;
-  title: string;
-  body: string;
-  timestamp: string;
-  isRead: boolean;
-}
-
-const MOCK_NOTIFICATIONS: Notification[] = [
-  {
-    id: '1',
-    type: 'payment',
-    title: 'Payment Due Soon',
-    body: "Your $50.00 payment is due in 3 days. Don't miss it!",
-    timestamp: '2 min ago',
-    isRead: false,
-  },
-  {
-    id: '2',
-    type: 'credit',
-    title: 'Credit Increased',
-    body: 'Great news! Your available credit increased to $320.00.',
-    timestamp: '1 hour ago',
-    isRead: false,
-  },
-  {
-    id: '3',
-    type: 'merchant',
-    title: 'New Merchant Available',
-    body: 'TechStore has joined TrustUp. Shop with BNPL now.',
-    timestamp: '3 hours ago',
-    isRead: false,
-  },
-  {
-    id: '4',
-    type: 'reputation',
-    title: 'Reputation Updated',
-    body: 'Your reputation score improved to 82/100. Keep it up!',
-    timestamp: 'Yesterday',
-    isRead: true,
-  },
-  {
-    id: '5',
-    type: 'security',
-    title: 'Terms Updated',
-    body: "We've updated our privacy policy. Tap to review the changes.",
-    timestamp: '3 days ago',
-    isRead: true,
-  },
-];
 
 const getIconConfig = (type: NotificationType) => {
   switch (type) {
@@ -107,20 +56,28 @@ interface NotificationsPanelProps {
 export const NotificationsPanel = ({ isOpen, onClose }: NotificationsPanelProps) => {
   const translateX = useSharedValue(SCREEN_WIDTH);
   const opacity = useSharedValue(0);
-  const [notifications, setNotifications] = useState<Notification[]>(MOCK_NOTIFICATIONS);
+  const [isMounted, setIsMounted] = useState(isOpen);
+  const { notifications, isLoading, markAsRead, markAllAsRead, deleteNotification } =
+    useNotifications();
 
   useEffect(() => {
     if (isOpen) {
+      setIsMounted(true);
       translateX.value = withTiming(0, {
         duration: 350,
         easing: Easing.out(Easing.exp),
       });
       opacity.value = withTiming(1, { duration: 300 });
     } else {
-      translateX.value = withTiming(SCREEN_WIDTH, {
-        duration: 300,
-        easing: Easing.in(Easing.exp),
-      });
+      // Only unmount once the close animation actually finishes, so a
+      // mid-animation re-render can't cut the slide-out short.
+      translateX.value = withTiming(
+        SCREEN_WIDTH,
+        { duration: 300, easing: Easing.in(Easing.exp) },
+        (finished) => {
+          if (finished) runOnJS(setIsMounted)(false);
+        }
+      );
       opacity.value = withTiming(0, { duration: 250 });
     }
   }, [isOpen, translateX, opacity]);
@@ -131,33 +88,25 @@ export const NotificationsPanel = ({ isOpen, onClose }: NotificationsPanelProps)
 
   const animatedBackdropStyle = useAnimatedStyle(() => ({
     opacity: opacity.value,
-    pointerEvents: isOpen ? 'auto' : 'none',
   }));
 
-  const handleMarkAsRead = (id: string) => {
-    setNotifications((prev) => prev.map((n) => (n.id === id ? { ...n, isRead: true } : n)));
-  };
-
-  const handleMarkAllAsRead = () => {
-    setNotifications((prev) => prev.map((n) => ({ ...n, isRead: true })));
-  };
-
-  const handleDelete = (id: string) => {
-    setNotifications((prev) => prev.filter((n) => n.id !== id));
-  };
-
-  if (!isOpen && translateX.value === SCREEN_WIDTH) return null;
+  if (!isMounted) return null;
 
   return (
     <View className="absolute inset-0" pointerEvents="box-none">
-      {/* Backdrop: absoluteFill + rgba bg kept as style (no Tailwind token for rgba(0,0,0,0.3)) */}
+      {/* Backdrop: absoluteFill + rgba bg kept as style (no Tailwind token for rgba(0,0,0,0.3)).
+          Position is inline (not className) because combining `pointerEvents` as a prop with
+          NativeWind's className on an Animated.View drops the className styles on web,
+          collapsing this to zero height. */}
       <Animated.View
-        className="absolute inset-0"
-        style={[styles.backdropColor, animatedBackdropStyle]}>
+        pointerEvents={isOpen ? 'auto' : 'none'}
+        style={[styles.backdropFill, styles.backdropColor, animatedBackdropStyle]}>
         <BlurView
           intensity={Platform.OS === 'ios' ? 20 : 40}
           tint="dark"
-          className="absolute inset-0">
+          className="absolute inset-0"
+          // BlurView is unreliable on Android — fall back to a plain rgba backdrop there.
+          style={Platform.OS === 'android' ? styles.androidBlurFallback : undefined}>
           <Pressable className="absolute inset-0" onPress={onClose} />
         </BlurView>
       </Animated.View>
@@ -171,7 +120,7 @@ export const NotificationsPanel = ({ isOpen, onClose }: NotificationsPanelProps)
           <View className="flex-row items-center justify-between px-6 pb-4 pt-8">
             <Text className="text-2xl font-bold text-primary">Notifications</Text>
             <View className="flex-row items-center gap-3">
-              <TouchableOpacity onPress={handleMarkAllAsRead}>
+              <TouchableOpacity onPress={markAllAsRead}>
                 <Text className="text-sm font-bold text-cta">Mark all read</Text>
               </TouchableOpacity>
               <TouchableOpacity
@@ -184,7 +133,19 @@ export const NotificationsPanel = ({ isOpen, onClose }: NotificationsPanelProps)
 
           {/* List */}
           <ScrollView className="flex-1" showsVerticalScrollIndicator={false}>
-            {notifications.length > 0 ? (
+            {isLoading ? (
+              <View>
+                {[0, 1, 2, 3].map((key) => (
+                  <View key={key} className="flex-row items-center px-4 py-4">
+                    <View className="h-10 w-10 rounded-full bg-gray-100" />
+                    <View className="flex-1 px-3">
+                      <View className="h-3 w-2/3 rounded bg-gray-100" />
+                      <View className="mt-2 h-3 w-full rounded bg-gray-100" />
+                    </View>
+                  </View>
+                ))}
+              </View>
+            ) : notifications.length > 0 ? (
               notifications.map((item) => {
                 const iconConfig = getIconConfig(item.type);
                 return (
@@ -222,11 +183,11 @@ export const NotificationsPanel = ({ isOpen, onClose }: NotificationsPanelProps)
                     {/* Actions */}
                     <View className="items-center gap-4 pt-1">
                       {!item.isRead && (
-                        <TouchableOpacity onPress={() => handleMarkAsRead(item.id)}>
+                        <TouchableOpacity onPress={() => markAsRead(item.id)}>
                           <Ionicons name="checkmark" size={20} color={colors.success} />
                         </TouchableOpacity>
                       )}
-                      <TouchableOpacity onPress={() => handleDelete(item.id)}>
+                      <TouchableOpacity onPress={() => deleteNotification(item.id)}>
                         <Ionicons name="trash-outline" size={18} color={colors.error} />
                       </TouchableOpacity>
                     </View>
@@ -237,7 +198,7 @@ export const NotificationsPanel = ({ isOpen, onClose }: NotificationsPanelProps)
               <View className="flex-1 items-center justify-center pt-32">
                 <Ionicons name="notifications-off-outline" size={48} color={colors.textSubtle} />
                 <Text className="mt-4 text-base font-medium text-textSecondary">
-                  All caught up!
+                  No notifications
                 </Text>
               </View>
             )}
@@ -249,9 +210,22 @@ export const NotificationsPanel = ({ isOpen, onClose }: NotificationsPanelProps)
 };
 
 const styles = StyleSheet.create({
+  // Inline (not className) — see comment above the backdrop Animated.View.
+  backdropFill: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+  },
   // rgba(0,0,0,0.3) has no Tailwind equivalent — kept as minimal style object
   backdropColor: {
     backgroundColor: 'rgba(0, 0, 0, 0.3)',
+  },
+  // BlurView's intensity is unreliable on Android — this rgba fallback keeps
+  // the backdrop visibly dimmed even when the native blur doesn't render.
+  androidBlurFallback: {
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
   },
   // Shadow props have no NativeWind equivalent in RN — kept as minimal style object
   panelShadow: {

--- a/hooks/notifications/use-notifications.ts
+++ b/hooks/notifications/use-notifications.ts
@@ -1,0 +1,153 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { Notification } from '../../types/Notification';
+
+// ─── Mock Data ────────────────────────────────────────────────────────────────
+
+const MOCK_NOTIFICATIONS: Notification[] = [
+  {
+    id: '1',
+    type: 'payment',
+    title: 'Payment Due Soon',
+    body: "Your $50.00 payment is due in 3 days. Don't miss it!",
+    timestamp: '2 min ago',
+    isRead: false,
+  },
+  {
+    id: '2',
+    type: 'credit',
+    title: 'Credit Increased',
+    body: 'Great news! Your available credit increased to $320.00.',
+    timestamp: '1 hour ago',
+    isRead: false,
+  },
+  {
+    id: '3',
+    type: 'merchant',
+    title: 'New Merchant Available',
+    body: 'TechStore has joined TrustUp. Shop with BNPL now.',
+    timestamp: '3 hours ago',
+    isRead: false,
+  },
+  {
+    id: '4',
+    type: 'reputation',
+    title: 'Reputation Updated',
+    body: 'Your reputation score improved to 82/100. Keep it up!',
+    timestamp: 'Yesterday',
+    isRead: true,
+  },
+  {
+    id: '5',
+    type: 'security',
+    title: 'Terms Updated',
+    body: "We've updated our privacy policy. Tap to review the changes.",
+    timestamp: '3 days ago',
+    isRead: true,
+  },
+];
+
+/** Simulates network latency for the mocked endpoints below. */
+const simulateRequest = <T>(result: T, delay = 400): Promise<T> =>
+  new Promise((resolve) => setTimeout(() => resolve(result), delay));
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+export interface UseNotificationsReturn {
+  notifications: Notification[];
+  unreadCount: number;
+  isLoading: boolean;
+  error: string | null;
+  markAsRead: (id: string) => void;
+  markAllAsRead: () => void;
+  deleteNotification: (id: string) => void;
+  refresh: () => void;
+}
+
+/**
+ * Custom hook for fetching and managing the user's notifications.
+ *
+ * @todo Replace the mock calls below with real network calls once the API
+ *   is available:
+ *   - `GET /notifications` (supports `?unread=true`)
+ *   - `PATCH /notifications/{id}/read`
+ *   - `PATCH /notifications/read-all`
+ *
+ * Until then, this hook simulates network delay with `setTimeout` so the
+ * panel's loading/empty states and optimistic updates can be built and
+ * reviewed. It MUST NOT ship to production in this state.
+ */
+export const useNotifications = (): UseNotificationsReturn => {
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchNotifications = useCallback(() => {
+    setIsLoading(true);
+    setError(null);
+
+    // TODO: replace with `apiFetch<NotificationsResponse>('/notifications')`
+    simulateRequest(MOCK_NOTIFICATIONS)
+      .then(setNotifications)
+      .catch(() => setError('Failed to load notifications'))
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  useEffect(() => {
+    fetchNotifications();
+  }, [fetchNotifications]);
+
+  const markAsRead = useCallback((id: string) => {
+    let previous: Notification[] = [];
+    setNotifications((prev) => {
+      previous = prev;
+      return prev.map((n) => (n.id === id ? { ...n, isRead: true } : n));
+    });
+
+    // TODO: replace with `apiFetch(`/notifications/${id}/read`, { method: 'PATCH' })`
+    simulateRequest(null).catch(() => {
+      setNotifications(previous);
+      setError('Failed to mark notification as read');
+    });
+  }, []);
+
+  const markAllAsRead = useCallback(() => {
+    let previous: Notification[] = [];
+    setNotifications((prev) => {
+      previous = prev;
+      return prev.map((n) => ({ ...n, isRead: true }));
+    });
+
+    // TODO: replace with `apiFetch('/notifications/read-all', { method: 'PATCH' })`
+    simulateRequest(null).catch(() => {
+      setNotifications(previous);
+      setError('Failed to mark all notifications as read');
+    });
+  }, []);
+
+  const deleteNotification = useCallback((id: string) => {
+    let previous: Notification[] = [];
+    setNotifications((prev) => {
+      previous = prev;
+      return prev.filter((n) => n.id !== id);
+    });
+
+    // No delete endpoint is documented yet — this stays local-only for now.
+    simulateRequest(null).catch(() => {
+      setNotifications(previous);
+      setError('Failed to delete notification');
+    });
+  }, []);
+
+  const unreadCount = notifications.reduce((count, n) => (n.isRead ? count : count + 1), 0);
+
+  return {
+    notifications,
+    unreadCount,
+    isLoading,
+    error,
+    markAsRead,
+    markAllAsRead,
+    deleteNotification,
+    refresh: fetchNotifications,
+  };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -2572,7 +2571,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -2586,7 +2584,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -2596,7 +2593,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -3374,7 +3370,7 @@
       "version": "19.1.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -4655,7 +4651,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4870,7 +4865,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -4916,7 +4910,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -4941,7 +4934,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -5324,7 +5316,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -5337,7 +5328,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-view-buffer": {
@@ -5543,14 +5534,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/doctrine": {
@@ -6668,6 +6657,21 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-linking": {
+      "version": "8.0.12",
+      "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-8.0.12.tgz",
+      "integrity": "sha512-FpXeIpFgZuxihwT9lBo86YD3y6LphBuAhN680MMxm/Y7fmsc57vimn2d3vFu68VI0+Z9w457t494mu2wvlgWTQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "expo-constants": "~18.0.13",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-modules-autolinking": {
       "version": "3.0.24",
       "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-3.0.24.tgz",
@@ -7544,7 +7548,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -7561,7 +7564,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -7587,7 +7589,6 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -7988,7 +7989,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -8446,7 +8446,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -8577,7 +8576,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8632,7 +8630,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -9228,7 +9225,6 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -9647,7 +9643,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -9870,7 +9865,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -10464,7 +10458,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -10939,7 +10932,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10991,7 +10983,6 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -11020,7 +11011,6 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -11038,7 +11028,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
       "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -11064,7 +11053,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
       "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -11107,7 +11095,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -11133,7 +11120,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -11399,7 +11385,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11485,6 +11470,19 @@
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
       "license": "MIT"
+    },
+    "node_modules/react-freeze": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/react-freeze/-/react-freeze-1.0.4.tgz",
+      "integrity": "sha512-r4F0Sec0BLxWicc7HEyo2x3/2icUTrRmDjaaRyzzn+7aDyFZliszMDOgLVwSnQnYENOlL1o569Ze2HZefk8clA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0"
+      }
     },
     "node_modules/react-is": {
       "version": "19.2.3",
@@ -11673,6 +11671,21 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz",
       "integrity": "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==",
       "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-screens": {
+      "version": "4.26.2",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.26.2.tgz",
+      "integrity": "sha512-2XnWsZToKj76trGtEZzx5ELD/qOICFEprEeUntImmitQFVUkea27fiWdUSITArI356Y1qynpXZINW+Unbhky/A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "react-freeze": "^1.0.0",
+        "warn-once": "^0.1.0"
+      },
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -11917,7 +11930,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -11927,7 +11939,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -12162,7 +12173,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -12210,7 +12220,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -13042,7 +13051,6 @@
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -13725,7 +13733,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/utils-merge": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -2571,6 +2572,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -2584,6 +2586,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -2593,6 +2596,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -3370,7 +3374,7 @@
       "version": "19.1.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -4651,6 +4655,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4865,6 +4870,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -4910,6 +4916,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -4934,6 +4941,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -5316,6 +5324,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -5328,7 +5337,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-view-buffer": {
@@ -5534,12 +5543,14 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/doctrine": {
@@ -6657,21 +6668,6 @@
         "expo": "*"
       }
     },
-    "node_modules/expo-linking": {
-      "version": "8.0.12",
-      "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-8.0.12.tgz",
-      "integrity": "sha512-FpXeIpFgZuxihwT9lBo86YD3y6LphBuAhN680MMxm/Y7fmsc57vimn2d3vFu68VI0+Z9w457t494mu2wvlgWTQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "expo-constants": "~18.0.13",
-        "invariant": "^2.2.4"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/expo-modules-autolinking": {
       "version": "3.0.24",
       "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-3.0.24.tgz",
@@ -7548,6 +7544,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -7564,6 +7561,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -7589,6 +7587,7 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -7989,6 +7988,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -8446,6 +8446,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -8576,6 +8577,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8630,6 +8632,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -9225,6 +9228,7 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -9643,6 +9647,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -9865,6 +9870,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -10458,6 +10464,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -10932,6 +10939,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10983,6 +10991,7 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -11011,6 +11020,7 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -11028,6 +11038,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
       "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -11053,6 +11064,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
       "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -11095,6 +11107,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -11120,6 +11133,7 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -11385,6 +11399,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11470,19 +11485,6 @@
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
       "license": "MIT"
-    },
-    "node_modules/react-freeze": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/react-freeze/-/react-freeze-1.0.4.tgz",
-      "integrity": "sha512-r4F0Sec0BLxWicc7HEyo2x3/2icUTrRmDjaaRyzzn+7aDyFZliszMDOgLVwSnQnYENOlL1o569Ze2HZefk8clA==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": ">=17.0.0"
-      }
     },
     "node_modules/react-is": {
       "version": "19.2.3",
@@ -11671,21 +11673,6 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz",
       "integrity": "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==",
       "license": "MIT",
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/react-native-screens": {
-      "version": "4.26.2",
-      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.26.2.tgz",
-      "integrity": "sha512-2XnWsZToKj76trGtEZzx5ELD/qOICFEprEeUntImmitQFVUkea27fiWdUSITArI356Y1qynpXZINW+Unbhky/A==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "react-freeze": "^1.0.0",
-        "warn-once": "^0.1.0"
-      },
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -11930,6 +11917,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -11939,6 +11927,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -12173,6 +12162,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -12220,6 +12210,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -13051,6 +13042,7 @@
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -13733,6 +13725,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/utils-merge": {

--- a/types/Notification.ts
+++ b/types/Notification.ts
@@ -1,0 +1,18 @@
+export type NotificationType = 'payment' | 'credit' | 'merchant' | 'reputation' | 'security';
+
+export interface Notification {
+  id: string;
+  type: NotificationType;
+  title: string;
+  body: string;
+  timestamp: string;
+  isRead: boolean;
+}
+
+/**
+ * Response shape from `GET /notifications`.
+ */
+export interface NotificationsResponse {
+  notifications: Notification[];
+  unreadCount: number;
+}


### PR DESCRIPTION
## 🔗 Related Issue
- closes #61

---

## 🔖 Title
Fix `NotificationsPanel` — connect to real API, fix animation close race condition, fix `pointerEvents` bug

---

## 📝 Description
`NotificationsPanel` had three bugs and used entirely hardcoded mock data:

1. **Animation close race condition**: the `translateX.value === SCREEN_WIDTH` render guard read the animated value at render time instead of waiting for the close animation to actually finish, so a mid-close re-render could unmount the panel and cut the slide-out short.
2. **`pointerEvents` as a style prop**: it lived inside `animatedBackdropStyle` (a `useAnimatedStyle` result), where it has no effect — `pointerEvents` is a prop on the element, not a style. The backdrop never blocked taps.
3. **All mock data**: `MOCK_NOTIFICATIONS` was a static array; mark-as-read/delete only touched local state, no API calls.

There's no backend yet for the three documented endpoints, so `hooks/notifications/use-notifications.ts` follows the same "mock hook, real shape, `@todo` markers" pattern already used by `use-loans.ts` / `use-loan-repayment.ts` in this repo — same data shape and optimistic-update behavior the real API will need, swappable later without touching the component.

---

## 🔄 Changes Made
- [x] Replaced the `translateX.value === SCREEN_WIDTH` guard with an `isMounted` state, flipped to `false` only from the `withTiming(...)` callback via `runOnJS` — the panel now always finishes its close animation before unmounting.
- [x] Moved `pointerEvents` off `animatedBackdropStyle` onto the backdrop `Animated.View` as a prop (`pointerEvents={isOpen ? 'auto' : 'none'}`).
  - Found on web while testing: combining that prop with NativeWind's `className` on a Reanimated `Animated.View` drops the `className` styles entirely (backdrop collapsed to zero height). Worked around by moving its `absolute inset-0` positioning to an inline style.
- [x] Added an Android fallback background (`rgba(0,0,0,0.5)`) for the backdrop, since `BlurView`'s `intensity` is unreliable on Android.
- [x] Added `types/Notification.ts` (`Notification`, `NotificationType`, `NotificationsResponse`).
- [x] Added `hooks/notifications/use-notifications.ts` — exposes `notifications`, `unreadCount`, `isLoading`, `markAsRead`, `markAllAsRead`, `deleteNotification`, all with optimistic updates + rollback on failure. `@todo` comments mark where `GET /notifications` (+`?unread=true`), `PATCH /notifications/{id}/read`, and `PATCH /notifications/read-all` go once the API exists. (No delete endpoint is documented yet, so delete stays local-only.)
- [x] `NotificationsPanel.tsx` now consumes the hook instead of local mock state: loading skeleton while fetching, "No notifications" empty state.
- [x] `Header.tsx` — real unread-count badge on the bell icon (red circle, hidden at 0, caps at "99+").
- [x] `MainLayout.tsx` — wires `useNotifications().unreadCount` into `Header`.
- [x] Fixed a pre-existing, unrelated bug in `MainLayout.tsx` found while wiring this up: it referenced `useProfile`, `getInitials`, `ProfileScreen`, `EditProfileScreen`, `isProfileOpen`, and `isEditProfileOpen` without importing or declaring any of them (already broken on `main`). Added the missing imports/state so the file type-checks and the Profile/Edit-Profile overlays render.

---

## 📸 Screenshots (if applicable)
Manually verified in Expo web (`npm run web`) with Playwright: panel opens with the 5 mock notifications, bell badge shows the correct unread count, "Mark all read" / individual mark-as-read / delete all update state correctly, and both the backdrop tap and the close button fully close the panel with the fixed animation.

---

## 🗒️ Additional Notes
- `tsc --noEmit` and `eslint` are clean on all changed files.
- No backend is running, so only the mocked hook contract is verified — the real endpoints themselves are untested. Follow-up: swap the `@todo`-marked mock calls in `use-notifications.ts` for real `apiFetch` calls once `GET`/`PATCH /notifications*` exist on the API.


https://github.com/user-attachments/assets/86701df3-0cc8-4662-9119-a1b66e3c1424

