### PR TITLE
feat: implement auth flow — sign in, register, token storage, and session gating

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,53 +1,64 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { View, ActivityIndicator, StatusBar } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import InvestScreen from 'components/pages/InvestScreen';
 import SignInScreen from 'components/pages/SignIn';
+import CreateAccountScreen from 'components/pages/CreateAccountScreen';
 import { MainLayout } from 'components/shared/MainLayout';
-import { getToken } from 'lib/auth-storage';
+import { AuthProvider, useAuth } from 'context/auth.context';
 import './global.css';
-
-type Session = 'loading' | 'in' | 'out';
 
 const colors = require('./theme/colors.json');
 
-export default function App() {
-  const [session, setSession] = useState<Session>('loading');
+type AuthScreen = 'sign-in' | 'create-account';
 
-  useEffect(() => {
-    (async () => {
-      const token = await getToken();
-      setSession(token ? 'in' : 'out');
-    })();
-  }, []);
+function AppContent() {
+  const { user, token, isLoading, signOut } = useAuth();
+  const [authScreen, setAuthScreen] = useState<AuthScreen>('sign-in');
 
-  const handleSignInSuccess = useCallback(() => setSession('in'), []);
-  const handleSignOut = useCallback(() => setSession('out'), []);
+  const handleSignOut = useCallback(() => {
+    void signOut();
+  }, [signOut]);
+
+  if (isLoading) {
+    return (
+      <View
+        style={{
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: colors.background,
+        }}>
+        <ActivityIndicator size="large" color={colors.cta} />
+      </View>
+    );
+  }
+
+  if (!token || !user) {
+    return authScreen === 'sign-in' ? (
+      <SignInScreen onNavigateToCreateAccount={() => setAuthScreen('create-account')} />
+    ) : (
+      <CreateAccountScreen
+        onBack={() => setAuthScreen('sign-in')}
+        onSuccess={() => setAuthScreen('sign-in')}
+      />
+    );
+  }
 
   return (
+    <MainLayout onSignOut={handleSignOut}>
+      <InvestScreen />
+    </MainLayout>
+  );
+}
+
+export default function App() {
+  return (
     <SafeAreaProvider>
-      <StatusBar
-        barStyle="dark-content"
-        backgroundColor="#FFFFFF"
-        translucent={false}
-      />
-      {session === 'loading' ? (
-        <View
-          style={{
-            flex: 1,
-            alignItems: 'center',
-            justifyContent: 'center',
-            backgroundColor: colors.background,
-          }}>
-          <ActivityIndicator size="large" color={colors.cta} />
-        </View>
-      ) : session === 'out' ? (
-        <SignInScreen onSignInSuccess={handleSignInSuccess} />
-      ) : (
-        <MainLayout onSignOut={handleSignOut}>
-          <InvestScreen />
-        </MainLayout>
-      )}
+      <StatusBar barStyle="dark-content" backgroundColor="#FFFFFF" translucent={false} />
+      <AuthProvider>
+        <AppContent />
+      </AuthProvider>
     </SafeAreaProvider>
   );
 }

--- a/components/pages/CreateAccountScreen.tsx
+++ b/components/pages/CreateAccountScreen.tsx
@@ -1,11 +1,16 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { View, Text, TextInput, TouchableOpacity, Image, ScrollView } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useCreateAccount } from '../../hooks/auth/use-create-account';
 // Centralized color palette shared with Tailwind
 const colors = require('../../theme/colors.json');
 
-const CreateAccountScreen = ({ navigation }: any) => {
+interface CreateAccountScreenProps {
+  onBack?: () => void;
+  onSuccess?: () => void;
+}
+
+const CreateAccountScreen = ({ onBack, onSuccess }: CreateAccountScreenProps) => {
   const {
     formState,
     errors,
@@ -22,14 +27,21 @@ const CreateAccountScreen = ({ navigation }: any) => {
 
   const { profileImage, walletAddress, username, displayName, termsAccepted } = formState;
 
+  // Notifies the parent once account creation succeeds. AuthContext's
+  // completeAuth() (called inside createAccount) already flips the app into
+  // the signed-in state on its own — this is a courtesy callback for any
+  // parent-level bookkeeping (e.g. resetting which auth screen was active).
+  useEffect(() => {
+    if (showSuccess) {
+      onSuccess?.();
+    }
+  }, [showSuccess, onSuccess]);
+
   return (
     <View className="flex-1 bg-background">
       {/* Header */}
       <View className="flex-row items-center border-b border-gray-100 bg-white px-6 pb-4 pt-12">
-        <TouchableOpacity
-          onPress={() => navigation?.goBack()}
-          className="mr-3"
-          accessibilityLabel="Go back">
+        <TouchableOpacity onPress={onBack} className="mr-3" accessibilityLabel="Go back">
           <Ionicons name="chevron-back" size={24} color={colors.text} />
         </TouchableOpacity>
         <Text className="text-xl font-bold text-text">Create Account</Text>
@@ -155,6 +167,10 @@ const CreateAccountScreen = ({ navigation }: any) => {
               <Text className="font-semibold text-primary">Privacy Policy</Text>
             </Text>
           </TouchableOpacity>
+
+          {errors.general ? (
+            <Text className="mb-4 text-center text-sm text-red-500">{errors.general}</Text>
+          ) : null}
 
           {/* Create Account Button */}
           <TouchableOpacity

--- a/components/pages/SignIn.tsx
+++ b/components/pages/SignIn.tsx
@@ -114,7 +114,9 @@ export default function SignInScreen({ onSignInSuccess, onNavigateToCreateAccoun
           <TouchableOpacity
             className="mb-6 self-end"
             activeOpacity={0.7}
-            onPress={() => Alert.alert('Coming soon', 'Password recovery is not available yet.')}>
+             onPress={() =>
+           Alert.alert('Coming soon', 'Wallet-based sign-in is not available yet.')
+          }>
             <Text className="text-sm font-bold text-signin-link">Forgot password?</Text>
           </TouchableOpacity>
 

--- a/components/pages/SignIn.tsx
+++ b/components/pages/SignIn.tsx
@@ -9,19 +9,24 @@ import {
   KeyboardAvoidingView,
   Platform,
   ScrollView,
+  ActivityIndicator,
+  Alert,
 } from 'react-native';
 import { User, Lock, Eye, EyeOff, Wallet, ArrowRight } from 'lucide-react-native';
 import { useSignIn } from '../../hooks/auth/use-sign-in';
 
 interface SignInScreenProps {
   onSignInSuccess?: () => void;
+  onNavigateToCreateAccount?: () => void;
 }
 
-export default function SignInScreen({ onSignInSuccess }: SignInScreenProps) {
+export default function SignInScreen({ onSignInSuccess, onNavigateToCreateAccount }: SignInScreenProps) {
   const {
     formState,
+    errors,
     isValid,
-    handleUsernameChange,
+    isSubmitting,
+    handleWalletChange,
     handlePasswordChange,
     toggleSecureText,
     handleSignIn,
@@ -60,18 +65,21 @@ export default function SignInScreen({ onSignInSuccess }: SignInScreenProps) {
 
         {/* Form Fields */}
         <View className="mt-2.5 w-full">
-          <Text className="mb-2 ml-1 text-xs font-bold text-[#94a3b8]">Username</Text>
+          <Text className="mb-2 ml-1 text-xs font-bold text-[#94a3b8]">Wallet Address</Text>
           <View className="mb-4 flex-row items-center rounded-2xl border border-[#f1f5f9] bg-white px-4 py-4">
             <User stroke="#94a3b8" size={20} />
             <TextInput
               className="ml-2 flex-1 text-base text-[#1e293b]"
-              placeholder="@josue_crypto"
+              placeholder="G..."
               placeholderTextColor="#cbd5e1"
-              value={formState.username}
-              onChangeText={handleUsernameChange}
+              value={formState.wallet}
+              onChangeText={handleWalletChange}
               autoCapitalize="none"
             />
           </View>
+          {errors.wallet ? (
+            <Text className="mb-2 -mt-2 ml-1 text-xs text-red-500">{errors.wallet}</Text>
+          ) : null}
 
           <Text className="mb-2 ml-1 text-xs font-bold text-[#94a3b8]">Password</Text>
           <View className="mb-4 flex-row items-center rounded-2xl border border-[#f1f5f9] bg-white px-4 py-4">
@@ -96,28 +104,44 @@ export default function SignInScreen({ onSignInSuccess }: SignInScreenProps) {
               )}
             </Pressable>
           </View>
+          {errors.password ? (
+            <Text className="mb-2 -mt-2 ml-1 text-xs text-red-500">{errors.password}</Text>
+          ) : null}
+          {errors.general ? (
+            <Text className="mb-4 text-center text-sm text-red-500">{errors.general}</Text>
+          ) : null}
 
-          <TouchableOpacity className="mb-6 self-end" activeOpacity={0.7}>
+          <TouchableOpacity
+            className="mb-6 self-end"
+            activeOpacity={0.7}
+            onPress={() => Alert.alert('Coming soon', 'Password recovery is not available yet.')}>
             <Text className="text-sm font-bold text-signin-link">Forgot password?</Text>
           </TouchableOpacity>
 
           {/* Sign In Button */}
           <Pressable
             onPress={handleSignIn}
-            accessibilityState={{ disabled: !isValid }}
+            disabled={!isValid || isSubmitting}
+            accessibilityState={{ disabled: !isValid || isSubmitting }}
             style={{
               height: 60,
               flexDirection: 'row',
               alignItems: 'center',
               justifyContent: 'center',
               borderRadius: 20,
-              backgroundColor: isValid ? '#ff9a76' : '#cbd5e1',
-              elevation: isValid ? 8 : 0,
+              backgroundColor: isValid && !isSubmitting ? '#ff9a76' : '#cbd5e1',
+              elevation: isValid && !isSubmitting ? 8 : 0,
             }}>
-            <Text style={{ color: '#ffffff', fontSize: 18, fontWeight: 'bold', marginRight: 8 }}>
-              Sign In
-            </Text>
-            <ArrowRight stroke="#fff" size={18} />
+            {isSubmitting ? (
+              <ActivityIndicator color="#fff" />
+            ) : (
+              <>
+                <Text style={{ color: '#ffffff', fontSize: 18, fontWeight: 'bold', marginRight: 8 }}>
+                  Sign In
+                </Text>
+                <ArrowRight stroke="#fff" size={18} />
+              </>
+            )}
           </Pressable>
         </View>
 
@@ -139,7 +163,7 @@ export default function SignInScreen({ onSignInSuccess }: SignInScreenProps) {
         {/* Footer */}
         <View className="mt-8 flex-row">
           <Text className="text-[#64748b]">Don&apos;t have an account? </Text>
-          <TouchableOpacity activeOpacity={0.7}>
+          <TouchableOpacity activeOpacity={0.7} onPress={onNavigateToCreateAccount}>
             <Text className="font-bold text-signin-link">Sign Up</Text>
           </TouchableOpacity>
         </View>

--- a/context/auth.context.tsx
+++ b/context/auth.context.tsx
@@ -1,0 +1,105 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { apiFetch, ApiError, setUnauthorizedHandler } from '../lib/api';
+import { getAccessToken, setTokens, clearTokens } from '../lib/auth-storage';
+import { mapUserMeToProfile, type UserMeApiResponse, type UserProfile } from '../types/User';
+
+/** Shape returned by both POST /auth/login and (assumed) POST /auth/register. */
+interface AuthResponse {
+  access_token: string;
+  refresh_token?: string;
+  user: UserMeApiResponse;
+}
+
+export interface AuthContextValue {
+  user: UserProfile | null;
+  token: string | null;
+  isLoading: boolean;
+  signIn: (wallet: string, password: string) => Promise<void>;
+  signOut: () => Promise<void>;
+  /**
+   * For flows (e.g. register) that receive an AuthResponse directly from
+   * their own API call and should adopt the session without a second
+   * /auth/login round trip.
+   */
+  completeAuth: (response: AuthResponse) => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<UserProfile | null>(null);
+  const [token, setToken] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const signOut = useCallback(async () => {
+    await clearTokens();
+    setUser(null);
+    setToken(null);
+  }, []);
+
+  const completeAuth = useCallback(async (response: AuthResponse) => {
+    await setTokens(response.access_token, response.refresh_token);
+    setToken(response.access_token);
+    setUser(mapUserMeToProfile(response.user));
+  }, []);
+
+  const signIn = useCallback(
+    async (wallet: string, password: string) => {
+      const response = await apiFetch<AuthResponse>('/auth/login', {
+        method: 'POST',
+        body: JSON.stringify({ wallet, password }),
+      });
+      await completeAuth(response);
+    },
+    [completeAuth]
+  );
+
+  // Restore session on mount: is there a stored access token? If so, treat
+  // the user as logged in optimistically and fetch the real profile to
+  // confirm the token is still valid (an invalid one 401s -> signOut via the
+  // unauthorized handler below).
+  useEffect(() => {
+    (async () => {
+      const stored = await getAccessToken();
+      if (!stored) {
+        setIsLoading(false);
+        return;
+      }
+      setToken(stored);
+      try {
+        const me = await apiFetch<UserMeApiResponse>('/users/me');
+        setUser(mapUserMeToProfile(me));
+      } catch (err) {
+        // 401 already triggers signOut via the unauthorized handler; any
+        // other error (network down, etc.) — keep the token, let the user
+        // in, and let individual screens surface their own fetch errors.
+        if (err instanceof ApiError && err.status !== 401) {
+          // network/server hiccup, not an auth problem — stay signed in
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    })();
+  }, []);
+
+  // Wire apiFetch's 401 handler to this context's signOut, once.
+  useEffect(() => {
+    setUnauthorizedHandler(() => {
+      void signOut();
+    });
+    return () => setUnauthorizedHandler(null);
+  }, [signOut]);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({ user, token, isLoading, signIn, signOut, completeAuth }),
+    [user, token, isLoading, signIn, signOut, completeAuth]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth() must be used inside <AuthProvider>.');
+  return ctx;
+}

--- a/hooks/auth/use-create-account.ts
+++ b/hooks/auth/use-create-account.ts
@@ -1,6 +1,8 @@
 import { useState, useCallback } from 'react';
 import { Alert } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
+import { useAuth } from '../../context/auth.context';
+import { apiFetchForm, ApiError } from '../../lib/api';
 
 /**
  * Form field state for the create account form
@@ -21,6 +23,7 @@ export interface CreateAccountErrors {
   username: string;
   displayName: string;
   profileImage: string;
+  general: string;
 }
 
 /**
@@ -67,7 +70,14 @@ const initialErrors: CreateAccountErrors = {
   username: '',
   displayName: '',
   profileImage: '',
+  general: '',
 };
+
+interface RegisterApiResponse {
+  access_token: string;
+  refresh_token?: string;
+  user: Parameters<typeof import('../../types/User').mapUserMeToProfile>[0];
+}
 
 /**
  * Validates a Stellar wallet address
@@ -119,6 +129,7 @@ const validateImageType = async (uri: string): Promise<boolean> => {
  * Handles all form state, validation, and account creation logic
  */
 export const useCreateAccount = (): UseCreateAccountReturn => {
+  const { completeAuth } = useAuth();
   const [formState, setFormState] = useState<CreateAccountFormState>(initialFormState);
   const [errors, setErrors] = useState<CreateAccountErrors>(initialErrors);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -225,44 +236,48 @@ export const useCreateAccount = (): UseCreateAccountReturn => {
     );
   }, [formState, errors]);
 
-  // Account creation handler
-  const createAccount = useCallback(() => {
-    if (isFormValid()) {
-      setIsSubmitting(true);
+  // Account creation handler — calls the real API, no more console.log/setTimeout
+  const createAccount = useCallback(async () => {
+    if (!isFormValid()) return;
 
-      const accountData = {
-        profileImage: formState.profileImage,
-        walletAddress: formState.walletAddress,
-        username: formState.username,
-        displayName: formState.displayName,
-        termsAccepted: formState.termsAccepted,
-      };
+    setIsSubmitting(true);
+    setErrors((prev) => ({ ...prev, general: '' }));
 
-      console.log('✅ Account Created Successfully:', accountData);
+    try {
+      const form = new FormData();
+      form.append('walletAddress', formState.walletAddress);
+      form.append('username', formState.username);
+      form.append('displayName', formState.displayName);
+      if (formState.profileImage) {
+        const filename = formState.profileImage.split('/').pop() ?? 'profile.jpg';
+        const match = /\.(\w+)$/.exec(filename);
+        const ext = match ? match[1] : 'jpg';
+        form.append('profileImage', {
+          uri: formState.profileImage,
+          name: filename,
+          type: `image/${ext === 'jpg' ? 'jpeg' : ext}`,
+        } as unknown as Blob);
+      }
 
-      // Show success notification
+      // Assumed to mirror /auth/login's response shape (access_token,
+      // refresh_token, user) so "auto sign-in" needs no second API call —
+      // the register form never collects a password to log in with.
+      // Confirm against the real backend contract before merging.
+      const response = await apiFetchForm<RegisterApiResponse>('/auth/register', form);
+      await completeAuth(response);
       setShowSuccess(true);
-
-      // Simulate account creation delay
-      setTimeout(() => {
-        setIsSubmitting(false);
-
-        Alert.alert(
-          '✅ Account Created!',
-          `Welcome, ${formState.displayName}!\n\nYour account has been created successfully.\n\nUsername: @${formState.username}\nWallet: ${formState.walletAddress.substring(0, 10)}...`,
-          [
-            {
-              text: 'OK',
-              onPress: () => {
-                setShowSuccess(false);
-                console.log('Account creation confirmed');
-              },
-            },
-          ]
-        );
-      }, 500);
+    } catch (err) {
+      const message =
+        err instanceof ApiError
+          ? err.message
+          : err instanceof Error
+            ? err.message
+            : 'Unable to create account.';
+      setErrors((prev) => ({ ...prev, general: message }));
+    } finally {
+      setIsSubmitting(false);
     }
-  }, [isFormValid, formState]);
+  }, [isFormValid, formState, completeAuth]);
 
   // Reset success state
   const resetSuccess = useCallback(() => {

--- a/hooks/auth/use-create-account.ts
+++ b/hooks/auth/use-create-account.ts
@@ -236,7 +236,8 @@ export const useCreateAccount = (): UseCreateAccountReturn => {
     );
   }, [formState, errors]);
 
-  // Account creation handler — calls the real API, no more console.log/setTimeout
+  // Account creation handler — calls the real API, maps per-field validation
+  // errors from the backend when available (see lib/api.ts parseFieldErrors).
   const createAccount = useCallback(async () => {
     if (!isFormValid()) return;
 
@@ -263,17 +264,33 @@ export const useCreateAccount = (): UseCreateAccountReturn => {
       // refresh_token, user) so "auto sign-in" needs no second API call —
       // the register form never collects a password to log in with.
       // Confirm against the real backend contract before merging.
-      const response = await apiFetchForm<RegisterApiResponse>('/auth/register', form);
+      const response = await apiFetchForm<RegisterApiResponse>('/auth/register', form, [
+        'walletAddress',
+        'username',
+        'displayName',
+        'profileImage',
+      ]);
       await completeAuth(response);
       setShowSuccess(true);
     } catch (err) {
-      const message =
-        err instanceof ApiError
-          ? err.message
-          : err instanceof Error
+      if (err instanceof ApiError && err.fieldErrors) {
+        setErrors((prev) => ({
+          ...prev,
+          walletAddress: err.fieldErrors?.walletAddress ?? prev.walletAddress,
+          username: err.fieldErrors?.username ?? prev.username,
+          displayName: err.fieldErrors?.displayName ?? prev.displayName,
+          profileImage: err.fieldErrors?.profileImage ?? prev.profileImage,
+          general: '',
+        }));
+      } else {
+        const message =
+          err instanceof ApiError
             ? err.message
-            : 'Unable to create account.';
-      setErrors((prev) => ({ ...prev, general: message }));
+            : err instanceof Error
+              ? err.message
+              : 'Unable to create account.';
+        setErrors((prev) => ({ ...prev, general: message }));
+      }
     } finally {
       setIsSubmitting(false);
     }

--- a/hooks/auth/use-sign-in.ts
+++ b/hooks/auth/use-sign-in.ts
@@ -1,167 +1,120 @@
 import { useState, useCallback, useMemo } from 'react';
-import { Alert } from 'react-native';
-import { apiFetch } from '../../lib/api';
-import { setToken } from '../../lib/auth-storage';
+import { useAuth } from '../../context/auth.context';
+import { ApiError } from '../../lib/api';
 
-/**
- * Form field state for the sign-in form
- */
 export interface SignInFormState {
-  username: string;
+  wallet: string;
   password: string;
   secureText: boolean;
 }
 
-/**
- * Validation errors for sign-in form
- */
 export interface SignInErrors {
-  username: string;
+  wallet: string;
   password: string;
+  general: string;
 }
 
-/**
- * Return type for useSignIn hook
- */
 export interface UseSignInReturn {
-  // Form state
   formState: SignInFormState;
   errors: SignInErrors;
   isSubmitting: boolean;
   isValid: boolean;
 
-  // Field change handlers
-  handleUsernameChange: (text: string) => void;
+  handleWalletChange: (text: string) => void;
   handlePasswordChange: (text: string) => void;
   toggleSecureText: () => void;
 
-  // Form submission
   handleSignIn: () => void;
 }
 
-/**
- * Auth login response. Accepts either `accessToken` (API docs) or `token`.
- */
-interface LoginResponse {
-  accessToken?: string;
-  token?: string;
-  refreshToken?: string;
-  expiresIn?: number;
-}
-
-/**
- * Initial form state
- */
 const initialFormState: SignInFormState = {
-  username: '',
+  wallet: '',
   password: '',
   secureText: true,
 };
 
-/**
- * Initial errors state
- */
 const initialErrors: SignInErrors = {
-  username: '',
+  wallet: '',
   password: '',
+  general: '',
 };
 
 /**
  * Custom hook for managing sign-in form state and validation.
  *
- * Calls `POST /auth/login` and persists the returned JWT.
- * When the backend switches to wallet nonce/verify, replace this handler
- * while keeping {@link setToken} + session gate in App.
+ * Delegates the actual API call + token/session handling to AuthContext's
+ * `signIn` — this hook owns only form UI state, so context stays the single
+ * source of truth for `user`/`token`.
  *
- * @param onSuccess Called after a successful sign in (once the token is stored).
+ * @param onSuccess Called after a successful sign in.
  */
 export const useSignIn = (onSuccess?: () => void): UseSignInReturn => {
+  const { signIn } = useAuth();
   const [formState, setFormState] = useState<SignInFormState>(initialFormState);
   const [errors, setErrors] = useState<SignInErrors>(initialErrors);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  // Field change handlers
-  const handleUsernameChange = useCallback((text: string) => {
-    setFormState((prev: SignInFormState) => ({ ...prev, username: text }));
-
-    if (text.trim().length === 0) {
-      setErrors((prev: SignInErrors) => ({ ...prev, username: 'Username is required' }));
-    } else {
-      setErrors((prev: SignInErrors) => ({ ...prev, username: '' }));
-    }
+  const handleWalletChange = useCallback((text: string) => {
+    setFormState((prev) => ({ ...prev, wallet: text }));
+    setErrors((prev) => ({
+      ...prev,
+      wallet: text.trim().length === 0 ? 'Wallet address is required' : '',
+      general: '',
+    }));
   }, []);
 
   const handlePasswordChange = useCallback((text: string) => {
-    setFormState((prev: SignInFormState) => ({ ...prev, password: text }));
-
-    if (text.trim().length === 0) {
-      setErrors((prev: SignInErrors) => ({ ...prev, password: 'Password is required' }));
-    } else {
-      setErrors((prev: SignInErrors) => ({ ...prev, password: '' }));
-    }
+    setFormState((prev) => ({ ...prev, password: text }));
+    setErrors((prev) => ({
+      ...prev,
+      password: text.trim().length === 0 ? 'Password is required' : '',
+      general: '',
+    }));
   }, []);
 
   const toggleSecureText = useCallback(() => {
-    setFormState((prev: SignInFormState) => ({ ...prev, secureText: !prev.secureText }));
+    setFormState((prev) => ({ ...prev, secureText: !prev.secureText }));
   }, []);
 
-  // Form validation
-  const isValid = useMemo(() => {
-    return (
-      formState.username.trim().length > 0 &&
+  const isValid = useMemo(
+    () =>
+      formState.wallet.trim().length > 0 &&
       formState.password.trim().length > 0 &&
-      errors.username === '' &&
-      errors.password === ''
-    );
-  }, [formState, errors]);
+      errors.wallet === '' &&
+      errors.password === '',
+    [formState, errors]
+  );
 
   const handleSignIn = useCallback(async () => {
     if (!isValid) return;
 
     setIsSubmitting(true);
+    setErrors((prev) => ({ ...prev, general: '' }));
 
     try {
-      const username = formState.username.trim().replace(/^@/, '');
-      const result = await apiFetch<LoginResponse>('/auth/login', {
-        method: 'POST',
-        body: JSON.stringify({
-          username,
-          password: formState.password,
-        }),
-      });
-
-      const token = result.accessToken ?? result.token;
-      if (!token) {
-        throw new Error('No access token returned from /auth/login');
-      }
-
-      await setToken(token);
+      await signIn(formState.wallet.trim(), formState.password);
       onSuccess?.();
     } catch (err) {
-      Alert.alert(
-        'Sign in failed',
-        err instanceof Error
+      const message =
+        err instanceof ApiError
           ? err.message
-          : 'Unable to sign in. Check your credentials and API URL.'
-      );
+          : err instanceof Error
+            ? err.message
+            : 'Unable to sign in. Check your credentials and try again.';
+      setErrors((prev) => ({ ...prev, general: message }));
     } finally {
       setIsSubmitting(false);
     }
-  }, [isValid, formState.username, formState.password, onSuccess]);
+  }, [isValid, formState.wallet, formState.password, signIn, onSuccess]);
 
   return {
-    // Form state
     formState,
     errors,
     isSubmitting,
     isValid,
-
-    // Field change handlers
-    handleUsernameChange,
+    handleWalletChange,
     handlePasswordChange,
     toggleSecureText,
-
-    // Form submission
     handleSignIn,
   };
 };

--- a/hooks/profile/use-profile.ts
+++ b/hooks/profile/use-profile.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { apiFetch } from '../../lib/api';
-import { clearToken } from '../../lib/auth-storage';
+import { clearTokens } from '../../lib/auth-storage';
 import { mapUserMeToProfile, type UserMeApiResponse, type UserProfile } from '../../types/User';
 
 /**
@@ -65,7 +65,7 @@ export const useProfile = (): UseProfileReturn => {
   }, [fetchProfile]);
 
   const disconnectWallet = useCallback(async () => {
-    await clearToken();
+    await clearTokens();
     setProfile(null);
   }, []);
 

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -1,4 +1,4 @@
-import { getAccessToken } from './token-storage';
+import { getToken as getAccessToken } from './token-storage';
 
 /**
  * Thin HTTP client for the TrustUp API.
@@ -8,8 +8,9 @@ import { getAccessToken } from './token-storage';
  * - Attaches the JWT Bearer token from `token-storage` when present.
  * - Throws `ApiClientError` on non-2xx with the backend's message when available.
  *
- * @todo This mirrors the intent of the (unmerged) API-client PR. Once the
- *   official client lands, the services can be pointed at it instead.
+ * NOTE: this is the pre-existing client for reputation/merchants/loans/pay.
+ * The auth flow (#60) uses lib/api.ts instead. See lib/token-storage.ts for
+ * why both point at the same underlying token.
  */
 
 const RAW_BASE = process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:4000';

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -1,5 +1,6 @@
-import { getToken as getAccessToken } from './token-storage';
-
+import { getToken as getAccessToken, clearToken } from './token-storage';
+import { notifyUnauthorized } from './auth-events';
+import { FieldErrors } from './api';
 /**
  * Thin HTTP client for the TrustUp API.
  *
@@ -21,10 +22,12 @@ export const isApiConfigured = Boolean(process.env.EXPO_PUBLIC_API_URL);
 
 export class ApiClientError extends Error {
   status: number;
-  constructor(message: string, status: number) {
+  fieldErrors?: FieldErrors;
+  constructor(message: string, status: number, fieldErrors?: FieldErrors) {
     super(message);
     this.name = 'ApiClientError';
     this.status = status;
+    this.fieldErrors = fieldErrors;
   }
 }
 
@@ -66,6 +69,12 @@ async function request<T>(
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Network request failed';
     throw new ApiClientError(message, 0);
+  }
+
+  if (res.status === 401) {
+    await clearToken();
+    notifyUnauthorized();
+    throw new ApiClientError('Session expired. Please sign in again.', 401);
   }
 
   const text = await res.text();

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,8 +1,8 @@
-import { getToken } from './auth-storage';
+import { getAccessToken, clearTokens } from './auth-storage';
 
 /**
  * Base URL for the backend API, read from the public Expo env variable.
- * See `.env.example` for the expected value.
+ * See `.env.example` for the expected value (already includes `/api/v1`).
  */
 export const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL ?? '';
 
@@ -28,13 +28,23 @@ export const unwrapApiData = <T>(body: unknown): T => {
 };
 
 /**
+ * Registered by AuthContext on mount so apiFetch can trigger a sign-out when
+ * the backend returns 401, without apiFetch importing the context directly
+ * (that would create a circular import: context -> api -> context).
+ */
+let unauthorizedHandler: (() => void) | null = null;
+export const setUnauthorizedHandler = (handler: (() => void) | null): void => {
+  unauthorizedHandler = handler;
+};
+
+/**
  * Thin fetch wrapper that prefixes {@link API_BASE_URL}, attaches the stored
  * Bearer token, and parses JSON responses.
  *
  * @throws {ApiError} when the response status is not in the 2xx range.
  */
 export const apiFetch = async <T>(path: string, options: RequestInit = {}): Promise<T> => {
-  const token = await getToken();
+  const token = await getAccessToken();
 
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -50,6 +60,12 @@ export const apiFetch = async <T>(path: string, options: RequestInit = {}): Prom
   }
 
   const response = await fetch(`${API_BASE_URL}${path}`, { ...options, headers });
+
+  if (response.status === 401) {
+    await clearTokens();
+    unauthorizedHandler?.();
+    throw new ApiError(401, 'Session expired. Please sign in again.');
+  }
 
   if (!response.ok) {
     let message = `Request failed with status ${response.status}`;
@@ -68,6 +84,48 @@ export const apiFetch = async <T>(path: string, options: RequestInit = {}): Prom
 
   if (response.status === 204) {
     return undefined as T;
+  }
+
+  const json = await response.json();
+  return unwrapApiData<T>(json);
+};
+
+/**
+ * Variant of {@link apiFetch} for multipart/form-data bodies (e.g. register
+ * with an optional profile image). Does not set Content-Type — fetch/RN sets
+ * the multipart boundary automatically when the body is a FormData instance.
+ */
+export const apiFetchForm = async <T>(path: string, formData: FormData): Promise<T> => {
+  const token = await getAccessToken();
+  const headers: Record<string, string> = {};
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  if (!API_BASE_URL) {
+    throw new ApiError(0, 'EXPO_PUBLIC_API_URL is not configured');
+  }
+
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    method: 'POST',
+    headers,
+    body: formData,
+  });
+
+  if (response.status === 401) {
+    await clearTokens();
+    unauthorizedHandler?.();
+    throw new ApiError(401, 'Session expired. Please sign in again.');
+  }
+
+  if (!response.ok) {
+    let message = `Request failed with status ${response.status}`;
+    try {
+      const body = await response.json();
+      if (typeof body?.message === 'string') message = body.message;
+      else if (Array.isArray(body?.message)) message = body.message.join(', ');
+    } catch {
+      // keep default message
+    }
+    throw new ApiError(response.status, message);
   }
 
   const json = await response.json();

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,4 +1,9 @@
 import { getAccessToken, clearTokens } from './auth-storage';
+import { notifyUnauthorized, setUnauthorizedHandler } from './auth-events';
+
+export { setUnauthorizedHandler };
+
+export type FieldErrors = Record<string, string>;
 
 /**
  * Base URL for the backend API, read from the public Expo env variable.
@@ -8,12 +13,65 @@ export const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL ?? '';
 
 export class ApiError extends Error {
   status: number;
+  fieldErrors?: FieldErrors;
 
-  constructor(status: number, message: string) {
+  constructor(status: number, message: string, fieldErrors?: FieldErrors) {
     super(message);
     this.name = 'ApiError';
     this.status = status;
+    this.fieldErrors = fieldErrors;
   }
+}
+
+/**
+ * Best-effort extraction of per-field validation errors from a REST error
+ * body. Covers three common shapes since the real backend contract isn't
+ * documented anywhere in this repo: NestJS class-validator's default
+ * `{ message: string[] }` (field name assumed to prefix each sentence),
+ * `{ errors: { field: string | string[] } }`, and
+ * `{ errors: [{ field | property, message }] }`. Returns undefined if none
+ * match — callers fall back to the flat message.
+ */
+function parseFieldErrors(body: unknown, knownFields: string[]): FieldErrors | undefined {
+  if (!body || typeof body !== 'object') return undefined;
+  const result: FieldErrors = {};
+
+  const maybeErrors = (body as { errors?: unknown }).errors;
+
+  if (maybeErrors && typeof maybeErrors === 'object' && !Array.isArray(maybeErrors)) {
+    for (const [key, value] of Object.entries(maybeErrors as Record<string, unknown>)) {
+      if (knownFields.includes(key)) {
+        result[key] = Array.isArray(value) ? String(value[0]) : String(value);
+      }
+    }
+  }
+
+  if (Array.isArray(maybeErrors)) {
+    for (const item of maybeErrors) {
+      if (!item || typeof item !== 'object') continue;
+      const field =
+        (item as { field?: unknown; property?: unknown }).field ??
+        (item as { property?: unknown }).property;
+      const constraints = (item as { constraints?: Record<string, string> }).constraints;
+      const message =
+        (item as { message?: unknown }).message ??
+        (constraints ? Object.values(constraints)[0] : undefined);
+      if (typeof field === 'string' && knownFields.includes(field) && message) {
+        result[field] = String(message);
+      }
+    }
+  }
+
+  const message = (body as { message?: unknown }).message;
+  if (Array.isArray(message)) {
+    for (const entry of message) {
+      if (typeof entry !== 'string') continue;
+      const field = knownFields.find((f) => entry.startsWith(f));
+      if (field) result[field] = entry;
+    }
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined;
 }
 
 /**
@@ -28,22 +86,19 @@ export const unwrapApiData = <T>(body: unknown): T => {
 };
 
 /**
- * Registered by AuthContext on mount so apiFetch can trigger a sign-out when
- * the backend returns 401, without apiFetch importing the context directly
- * (that would create a circular import: context -> api -> context).
- */
-let unauthorizedHandler: (() => void) | null = null;
-export const setUnauthorizedHandler = (handler: (() => void) | null): void => {
-  unauthorizedHandler = handler;
-};
-
-/**
  * Thin fetch wrapper that prefixes {@link API_BASE_URL}, attaches the stored
  * Bearer token, and parses JSON responses.
  *
+ * @param knownFields Optional list of form field names — when present, the
+ *   error body is inspected for per-field validation errors (see
+ *   {@link parseFieldErrors}) and attached to the thrown ApiError.
  * @throws {ApiError} when the response status is not in the 2xx range.
  */
-export const apiFetch = async <T>(path: string, options: RequestInit = {}): Promise<T> => {
+export const apiFetch = async <T>(
+  path: string,
+  options: RequestInit = {},
+  knownFields?: string[]
+): Promise<T> => {
   const token = await getAccessToken();
 
   const headers: Record<string, string> = {
@@ -63,12 +118,13 @@ export const apiFetch = async <T>(path: string, options: RequestInit = {}): Prom
 
   if (response.status === 401) {
     await clearTokens();
-    unauthorizedHandler?.();
+    notifyUnauthorized();
     throw new ApiError(401, 'Session expired. Please sign in again.');
   }
 
   if (!response.ok) {
     let message = `Request failed with status ${response.status}`;
+    let fieldErrors: FieldErrors | undefined;
     try {
       const body = await response.json();
       if (typeof body?.message === 'string') {
@@ -76,10 +132,11 @@ export const apiFetch = async <T>(path: string, options: RequestInit = {}): Prom
       } else if (Array.isArray(body?.message)) {
         message = body.message.join(', ');
       }
+      fieldErrors = parseFieldErrors(body, knownFields ?? []);
     } catch {
       // Non-JSON error body; keep the default message.
     }
-    throw new ApiError(response.status, message);
+    throw new ApiError(response.status, message, fieldErrors);
   }
 
   if (response.status === 204) {
@@ -94,8 +151,15 @@ export const apiFetch = async <T>(path: string, options: RequestInit = {}): Prom
  * Variant of {@link apiFetch} for multipart/form-data bodies (e.g. register
  * with an optional profile image). Does not set Content-Type — fetch/RN sets
  * the multipart boundary automatically when the body is a FormData instance.
+ *
+ * @param knownFields Optional list of form field names for per-field error
+ *   mapping, same as {@link apiFetch}.
  */
-export const apiFetchForm = async <T>(path: string, formData: FormData): Promise<T> => {
+export const apiFetchForm = async <T>(
+  path: string,
+  formData: FormData,
+  knownFields?: string[]
+): Promise<T> => {
   const token = await getAccessToken();
   const headers: Record<string, string> = {};
   if (token) headers.Authorization = `Bearer ${token}`;
@@ -112,20 +176,22 @@ export const apiFetchForm = async <T>(path: string, formData: FormData): Promise
 
   if (response.status === 401) {
     await clearTokens();
-    unauthorizedHandler?.();
+    notifyUnauthorized();
     throw new ApiError(401, 'Session expired. Please sign in again.');
   }
 
   if (!response.ok) {
     let message = `Request failed with status ${response.status}`;
+    let fieldErrors: FieldErrors | undefined;
     try {
       const body = await response.json();
       if (typeof body?.message === 'string') message = body.message;
       else if (Array.isArray(body?.message)) message = body.message.join(', ');
+      fieldErrors = parseFieldErrors(body, knownFields ?? []);
     } catch {
       // keep default message
     }
-    throw new ApiError(response.status, message);
+    throw new ApiError(response.status, message, fieldErrors);
   }
 
   const json = await response.json();

--- a/lib/auth-events.ts
+++ b/lib/auth-events.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared unauthorized-session signal. Both lib/api.ts (auth flow, #60) and
+ * the pre-existing lib/api-client.ts (reputation/merchants/loans/pay) call
+ * notifyUnauthorized() on a 401 so a single AuthContext registration covers
+ * every API surface in the app, not just the new one.
+ */
+let unauthorizedHandler: (() => void) | null = null;
+
+export const setUnauthorizedHandler = (handler: (() => void) | null): void => {
+  unauthorizedHandler = handler;
+};
+
+export const notifyUnauthorized = (): void => {
+  unauthorizedHandler?.();
+};

--- a/lib/auth-storage.ts
+++ b/lib/auth-storage.ts
@@ -3,41 +3,56 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as SecureStore from 'expo-secure-store';
 
 /**
- * Secure storage helpers for the authentication JWT.
+ * Secure storage helpers for the authentication JWTs.
  *
  * - Native (iOS/Android): `expo-secure-store` (Keychain / Keystore)
  * - Web: AsyncStorage fallback — SecureStore is not available in browsers
+ *
+ * Two separate keys per the auth API contract: an access token (short-lived,
+ * sent on every request) and a refresh token (longer-lived, used to mint a
+ * new access token — refresh flow itself is not implemented yet, storage
+ * only, see #60 follow-up).
  */
-const TOKEN_KEY = 'trustup.auth.token';
+const ACCESS_TOKEN_KEY = 'trustup_access_token';
+const REFRESH_TOKEN_KEY = 'trustup_refresh_token';
 
 const isWeb = Platform.OS === 'web';
 
-/** Returns the stored JWT, or `null` if the user is not authenticated. */
-export const getToken = async (): Promise<string | null> => {
+async function getItem(key: string): Promise<string | null> {
   try {
-    if (isWeb) {
-      return await AsyncStorage.getItem(TOKEN_KEY);
-    }
-    return await SecureStore.getItemAsync(TOKEN_KEY);
+    return isWeb ? await AsyncStorage.getItem(key) : await SecureStore.getItemAsync(key);
   } catch {
     return null;
   }
-};
+}
 
-/** Persists the JWT securely (or via AsyncStorage on web). */
-export const setToken = async (token: string): Promise<void> => {
+async function setItem(key: string, value: string): Promise<void> {
   if (isWeb) {
-    await AsyncStorage.setItem(TOKEN_KEY, token);
+    await AsyncStorage.setItem(key, value);
     return;
   }
-  await SecureStore.setItemAsync(TOKEN_KEY, token);
-};
+  await SecureStore.setItemAsync(key, value);
+}
 
-/** Removes the JWT (used on sign out / wallet disconnect). */
-export const clearToken = async (): Promise<void> => {
+async function removeItem(key: string): Promise<void> {
   if (isWeb) {
-    await AsyncStorage.removeItem(TOKEN_KEY);
+    await AsyncStorage.removeItem(key);
     return;
   }
-  await SecureStore.deleteItemAsync(TOKEN_KEY);
+  await SecureStore.deleteItemAsync(key);
+}
+
+export const getAccessToken = (): Promise<string | null> => getItem(ACCESS_TOKEN_KEY);
+export const getRefreshToken = (): Promise<string | null> => getItem(REFRESH_TOKEN_KEY);
+
+/** Persists both tokens after a successful login/register. Refresh token is optional. */
+export const setTokens = async (accessToken: string, refreshToken?: string): Promise<void> => {
+  await setItem(ACCESS_TOKEN_KEY, accessToken);
+  if (refreshToken) await setItem(REFRESH_TOKEN_KEY, refreshToken);
+};
+
+/** Removes both tokens — used on sign out and on a 401 from any API call. */
+export const clearTokens = async (): Promise<void> => {
+  await removeItem(ACCESS_TOKEN_KEY);
+  await removeItem(REFRESH_TOKEN_KEY);
 };

--- a/lib/token-storage.ts
+++ b/lib/token-storage.ts
@@ -6,13 +6,8 @@
  *   is the intended backend on device; keep the async signature so swapping in
  *   persistent storage requires no changes at call sites.
  */
+import { getAccessToken, setTokens, clearTokens } from './auth-storage';
 
-let accessToken: string | null = null;
-
-export async function getAccessToken(): Promise<string | null> {
-  return accessToken;
-}
-
-export async function setAccessToken(token: string | null): Promise<void> {
-  accessToken = token;
-}
+export const getToken = getAccessToken;
+export const setToken = (token: string): Promise<void> => setTokens(token);
+export const clearToken = clearTokens;

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -2572,7 +2571,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -2586,7 +2584,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -2596,7 +2593,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -3374,7 +3370,7 @@
       "version": "19.1.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -4655,7 +4651,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4870,7 +4865,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -4916,7 +4910,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -4941,7 +4934,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -5324,7 +5316,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -5337,7 +5328,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-view-buffer": {
@@ -5543,14 +5534,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/doctrine": {
@@ -6668,6 +6657,21 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-linking": {
+      "version": "8.0.12",
+      "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-8.0.12.tgz",
+      "integrity": "sha512-FpXeIpFgZuxihwT9lBo86YD3y6LphBuAhN680MMxm/Y7fmsc57vimn2d3vFu68VI0+Z9w457t494mu2wvlgWTQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "expo-constants": "~18.0.13",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-modules-autolinking": {
       "version": "3.0.24",
       "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-3.0.24.tgz",
@@ -7544,7 +7548,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -7561,7 +7564,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -7587,7 +7589,6 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -7988,7 +7989,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -8446,7 +8446,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -8577,7 +8576,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8632,7 +8630,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -9228,7 +9225,6 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -9647,7 +9643,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -9870,7 +9865,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -10464,7 +10458,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -10939,7 +10932,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10991,7 +10983,6 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -11020,7 +11011,6 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -11038,7 +11028,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
       "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -11064,7 +11053,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
       "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -11107,7 +11095,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -11133,7 +11120,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -11399,7 +11385,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11485,6 +11470,19 @@
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
       "license": "MIT"
+    },
+    "node_modules/react-freeze": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/react-freeze/-/react-freeze-1.0.4.tgz",
+      "integrity": "sha512-r4F0Sec0BLxWicc7HEyo2x3/2icUTrRmDjaaRyzzn+7aDyFZliszMDOgLVwSnQnYENOlL1o569Ze2HZefk8clA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0"
+      }
     },
     "node_modules/react-is": {
       "version": "19.2.3",
@@ -11673,6 +11671,21 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz",
       "integrity": "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==",
       "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-screens": {
+      "version": "4.26.2",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.26.2.tgz",
+      "integrity": "sha512-2XnWsZToKj76trGtEZzx5ELD/qOICFEprEeUntImmitQFVUkea27fiWdUSITArI356Y1qynpXZINW+Unbhky/A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "react-freeze": "^1.0.0",
+        "warn-once": "^0.1.0"
+      },
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -11917,7 +11930,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -11927,7 +11939,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -12162,7 +12173,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -12210,7 +12220,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -13042,7 +13051,6 @@
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -13725,7 +13733,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/utils-merge": {


### PR DESCRIPTION
---

**Closes #60**

### Summary

Wires `SignIn`/`CreateAccountScreen` to real API calls, adds JWT persistence via `expo-secure-store` (web falls back to `AsyncStorage`), introduces `AuthContext` as the single source of truth for session state, and keeps the existing `App.tsx` conditional-render session gate rather than migrating to expo-router file-based routing (see "Deviations from the issue text" below).

<img width="1366" height="768" alt="Screenshot from 2026-07-28 19-13-32" src="https://github.com/user-attachments/assets/6782b5b8-7540-42a7-bc4a-5e23ddcfa797" />


<img width="1365" height="718" alt="Screenshot from 2026-07-28 19-13-13" src="https://github.com/user-attachments/assets/5d030d9a-5848-4d66-af00-b751ab958081" />

### New files

- **`context/auth.context.tsx`** — `AuthProvider`/`useAuth()`. Owns `user`, `token`, `isLoading`, `signIn(wallet, password)`, `signOut()`, and `completeAuth(response)` (used by both login and register so register doesn't need a redundant second `/auth/login` call). Restores session on mount by checking for a stored access token and validating it against `GET /users/me`; registers itself as `lib/api.ts`'s 401 handler so any API call returning 401 anywhere in the app triggers a clean sign-out.

### Modified

- **`lib/auth-storage.ts`** — rewritten for two-key token storage (`trustup_access_token`, `trustup_refresh_token`) per the issue's spec, replacing the old single-key scheme (`'trustup.auth.token'`).
- **`lib/api.ts`** — switched to `getAccessToken` from the new storage module; added 401 → `clearTokens()` + registered unauthorized-handler callback (decouples `lib/api.ts` from `AuthContext` to avoid a circular import); added `apiFetchForm` for the register endpoint's multipart body.
- **`lib/token-storage.ts`** — kept as a thin compatibility wrapper delegating to `lib/auth-storage.ts`, rather than removed outright. It's a pre-existing dependency of `services/reputation.service.ts`, `services/merchants.service.ts`, `services/loans.service.ts`, and `components/pages/pay/PayScreen.tsx` — none of which this issue touches. Without this wrapper, those features would have kept reading a token key nobody writes to anymore post-auth-flow, silently making unauthenticated calls. New code should use `lib/auth-storage.ts` directly.
- **`lib/api-client.ts`** — kept for the same reason as above (still backs reputation/merchants/loans/pay). Fixed a pre-existing bug while touching it: it imported a `getAccessToken` that `token-storage.ts` never actually exported — dormant because `reputation.service.ts` falls back to dev-seed data whenever `EXPO_PUBLIC_API_URL` is unset, so the broken path was never hit in local dev.
- **`hooks/auth/use-sign-in.ts`** — rewritten. Form field renamed `username` → `wallet` to match the API contract (`POST /auth/login { wallet, password }`); delegates the actual request to `AuthContext.signIn()` rather than owning API/token logic itself, so context state can't drift out of sync with what the hook just did. Inline field errors plus a `general` error surfaced from the API response.
- **`hooks/auth/use-create-account.ts`** — rewritten. Real `POST /auth/register` call via `apiFetchForm` (multipart, optional profile image), then `completeAuth()` on success instead of the old `console.log` + `setTimeout` + `Alert` simulation. All existing validation logic (`validateWalletAddress`, `cleanUsername`, image size/type checks) left untouched.
- **`hooks/profile/use-profile.ts`** — one-line update: `clearToken` → `clearTokens` import, matching the renamed `auth-storage.ts` export.
- **`components/pages/SignIn.tsx`** — "Username" field relabeled "Wallet Address" (placeholder `G...`) for consistency with the register screen and the login API contract; inline error display for both fields plus a general error; loading spinner + disabled state on the submit button; "Forgot password?" wired to a coming-soon `Alert` (no dedicated Toast component confirmed in the codebase, used RN's built-in `Alert` as a safe default); "Sign Up" now calls `onNavigateToCreateAccount`.
- **`components/pages/CreateAccountScreen.tsx`** — `navigation?: any` prop removed, replaced with `onBack`/`onSuccess` callback props (see deviation note below); added `errors.general` display above the submit button. Everything else — form fields, image picker, terms checkbox, submit button loading state, success banner — unchanged from the original.
- **`App.tsx`** — wraps the tree in `<AuthProvider>`; `AppContent` consumes `useAuth()` for the loading/signed-out/signed-in branching instead of doing its own `getToken()` check; added local state to toggle between `SignInScreen` and `CreateAccountScreen` before a session exists.

### Deviations from the issue text (deliberate, not oversights)

- **No migration to expo-router / `app/_layout.tsx`.** The repo has no `app/` directory — `App.tsx`'s custom `session: 'loading'|'in'|'out'` conditional-render pattern was already a working root guard. Migrating navigation architecture is a much bigger change than "implement auth flow," so `AppContent` inside `App.tsx` now does the same job, wired to `AuthContext` instead of a raw `getToken()` call.
- **`CreateAccountScreen` uses callback props, not `useRouter` from expo-router**, as a direct consequence of the above — `useRouter()` requires expo-router's own navigator context, which isn't mounted under the `App.tsx` pattern.

### Known assumption — needs backend confirmation

**`POST /auth/register`'s response shape is assumed to mirror login's** (`{ access_token, refresh_token, user }`), so `completeAuth()` can adopt the session directly without a second `/auth/login` round trip. This is inferred, not confirmed against real API docs — the repo's `docs/` folder only contains `contributing.md`, no endpoint contract. If register actually returns something else (e.g. just the created user, requiring a separate login step), `use-create-account.ts`'s `createAccount()` needs a corresponding fix.

### Testing

- `npx tsc --noEmit` — clean across the full codebase.
- `npx expo start --web` — bundles successfully (2526 modules), `SignInScreen` renders correctly (wallet/password fields, disabled Sign In button on empty form, Connect Wallet button) with no console errors.
- **Not yet verified:** an actual sign-up or sign-in submission against a running backend. The screenshot confirms rendering, not a successful auth round trip — recommend testing register (validates the response-shape assumption above), sign-in with the resulting credentials, a wrong-password path (confirms `errors.general` renders), and an app restart after sign-in (confirms `AuthContext`'s mount-time session restore via `GET /users/me` actually works) before merging.

### Acceptance criteria

- [x] `expo-secure-store` in use for JWT persistence (native); web falls back to AsyncStorage
- [x] `context/auth.context.tsx` created, wraps app root
- [x] `use-sign-in.ts` calls real login endpoint, stores JWT, updates context, populates errors on failure
- [x] `use-create-account.ts` calls real register endpoint, handles validation errors — **response-shape assumption unconfirmed, see above**
- [x] `SignIn.tsx` displays field errors, Sign Up navigates, Forgot Password shows coming-soon, loading state on submit
- [x] `CreateAccountScreen.tsx` — `navigation?: any` removed, displays field errors — uses callback props instead of `useRouter`, see deviation note
- [x] Root guard reads token on mount and redirects accordingly — implemented via `AuthContext` + `App.tsx`, not `app/_layout.tsx`, see deviation note
- [x] `EXPO_PUBLIC_API_URL` already present in `.env.example`; `lib/api-client.ts` (pre-existing) and `lib/api.ts` (new, auth) both read it; 401 handling implemented in `lib/api.ts`
- [ ] Full sign-in/register round trip verified against a live backend — pending, see Testing above