### PR TITLE
fix(config): rebrand Expo app.json and cesconfig to TrustUp (#78)

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
-    "name": "my-expo-app",
-    "slug": "my-expo-app",
+    "name": "TrustUp",
+    "slug": "trustup",
     "version": "1.0.0",
     "web": {
       "favicon": "./assets/favicon.png"

--- a/cesconfig.jsonc
+++ b/cesconfig.jsonc
@@ -2,7 +2,7 @@
 // It is safe to delete this file as it does not affect the functionality of your application.
 {
   "cesVersion": "2.20.1",
-  "projectName": "my-expo-app",
+  "projectName": "trustup",
   "packages": [
     {
       "name": "nativewind",


### PR DESCRIPTION
## 🔗 Related Issue
Closes #78

---

## 🔖 Title
Rebrand Expo app.json from my-expo-app to TrustUp

---

## 📝 Description
`app.json` and `cesconfig.jsonc` previously used the initial template starter identity (`my-expo-app`), causing device home screens, Expo Go, and build configs to show the wrong name instead of the actual product name **TrustUp**.

This PR updates `expo.name` and `expo.slug` in `app.json` to `TrustUp` / `trustup`, and aligns `cesconfig.jsonc` with the product identity, keeping all existing icon, splash, and asset configurations intact.

---

## 🔄 Changes Made
- [x] Updated `app.json` `expo.name` to `TrustUp` and `expo.slug` to `trustup`
- [x] Updated `cesconfig.jsonc` `projectName` to `trustup`
- [x] Verified no remaining `my-expo-app` references across configuration files
- [x] Preserved asset paths, orientation, plugins, and bundle patterns

---

## 📸 Screenshots (if applicable)
_N/A - Configuration change for Expo application identity and metadata._

---

## 🗒️ Additional Notes
- No changes made to bundle identifiers or package names outside required Expo metadata.
