### PR TITLE
feat: wire notifications hook to GET /notifications API

### DIFF
--- a/hooks/notifications/use-notifications.ts
+++ b/hooks/notifications/use-notifications.ts
@@ -1,54 +1,10 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { Notification } from '../../types/Notification';
-
-// ─── Mock Data ────────────────────────────────────────────────────────────────
-
-const MOCK_NOTIFICATIONS: Notification[] = [
-  {
-    id: '1',
-    type: 'payment',
-    title: 'Payment Due Soon',
-    body: "Your $50.00 payment is due in 3 days. Don't miss it!",
-    timestamp: '2 min ago',
-    isRead: false,
-  },
-  {
-    id: '2',
-    type: 'credit',
-    title: 'Credit Increased',
-    body: 'Great news! Your available credit increased to $320.00.',
-    timestamp: '1 hour ago',
-    isRead: false,
-  },
-  {
-    id: '3',
-    type: 'merchant',
-    title: 'New Merchant Available',
-    body: 'TechStore has joined TrustUp. Shop with BNPL now.',
-    timestamp: '3 hours ago',
-    isRead: false,
-  },
-  {
-    id: '4',
-    type: 'reputation',
-    title: 'Reputation Updated',
-    body: 'Your reputation score improved to 82/100. Keep it up!',
-    timestamp: 'Yesterday',
-    isRead: true,
-  },
-  {
-    id: '5',
-    type: 'security',
-    title: 'Terms Updated',
-    body: "We've updated our privacy policy. Tap to review the changes.",
-    timestamp: '3 days ago',
-    isRead: true,
-  },
-];
-
-/** Simulates network latency for the mocked endpoints below. */
-const simulateRequest = <T>(result: T, delay = 400): Promise<T> =>
-  new Promise((resolve) => setTimeout(() => resolve(result), delay));
+import {
+  getNotifications,
+  markAllNotificationsRead,
+  markNotificationRead,
+} from '../../services/notifications.service';
 
 // ─── Hook ─────────────────────────────────────────────────────────────────────
 
@@ -59,6 +15,14 @@ export interface UseNotificationsReturn {
   error: string | null;
   markAsRead: (id: string) => void;
   markAllAsRead: () => void;
+  /**
+   * Removes a notification from the local list.
+   *
+   * NOTE: The TrustUp API does not expose a delete endpoint (as of API-23/24
+   * documentation). This operation is intentionally local-only and will NOT
+   * persist across sessions or devices. If a delete endpoint is added in the
+   * future, this function should be wired to it.
+   */
   deleteNotification: (id: string) => void;
   refresh: () => void;
 }
@@ -66,36 +30,60 @@ export interface UseNotificationsReturn {
 /**
  * Custom hook for fetching and managing the user's notifications.
  *
- * @todo Replace the mock calls below with real network calls once the API
- *   is available:
- *   - `GET /notifications` (supports `?unread=true`)
- *   - `PATCH /notifications/{id}/read`
- *   - `PATCH /notifications/read-all`
- *
- * Until then, this hook simulates network delay with `setTimeout` so the
- * panel's loading/empty states and optimistic updates can be built and
- * reviewed. It MUST NOT ship to production in this state.
+ * - Fetches from `GET /notifications` via `notifications.service.ts`.
+ * - `markAsRead` / `markAllAsRead` apply optimistic updates and roll back on
+ *   server failure.
+ * - `deleteNotification` is local-only (no delete endpoint in the API).
+ * - Falls back to a DEV seed when `EXPO_PUBLIC_API_URL` is not configured
+ *   (same `isApiConfigured` pattern as loans/merchants services).
  */
 export const useNotifications = (): UseNotificationsReturn => {
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Keep a stable abort-controller ref so fetchNotifications can be safely
+  // cancelled on unmount or when the caller calls refresh().
+  const abortRef = useRef<AbortController | null>(null);
+
   const fetchNotifications = useCallback(() => {
+    // Cancel any in-flight request before starting a new one.
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
     setIsLoading(true);
     setError(null);
 
-    // TODO: replace with `apiFetch<NotificationsResponse>('/notifications')`
-    simulateRequest(MOCK_NOTIFICATIONS)
-      .then(setNotifications)
-      .catch(() => setError('Failed to load notifications'))
-      .finally(() => setIsLoading(false));
+    getNotifications({ signal: controller.signal })
+      .then(({ notifications: fetched }) => {
+        setNotifications(fetched);
+      })
+      .catch((err: unknown) => {
+        // Ignore aborted requests — they are expected on unmount / refresh.
+        if (err instanceof Error && err.name === 'AbortError') return;
+        setError('Failed to load notifications');
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
   }, []);
 
   useEffect(() => {
     fetchNotifications();
+    return () => {
+      // Cancel the in-flight request when the component unmounts.
+      abortRef.current?.abort();
+    };
   }, [fetchNotifications]);
 
+  /**
+   * Marks a single notification as read.
+   *
+   * Applies the update immediately (optimistic), then confirms with
+   * `PATCH /notifications/:id/read`. Rolls back and surfaces an error on
+   * failure.
+   */
   const markAsRead = useCallback((id: string) => {
     let previous: Notification[] = [];
     setNotifications((prev) => {
@@ -103,13 +91,20 @@ export const useNotifications = (): UseNotificationsReturn => {
       return prev.map((n) => (n.id === id ? { ...n, isRead: true } : n));
     });
 
-    // TODO: replace with `apiFetch(`/notifications/${id}/read`, { method: 'PATCH' })`
-    simulateRequest(null).catch(() => {
+    markNotificationRead(id).catch((err: unknown) => {
+      if (err instanceof Error && err.name === 'AbortError') return;
       setNotifications(previous);
       setError('Failed to mark notification as read');
     });
   }, []);
 
+  /**
+   * Marks all notifications as read.
+   *
+   * Applies the update immediately (optimistic), then confirms with
+   * `PATCH /notifications/read-all`. Rolls back and surfaces an error on
+   * failure.
+   */
   const markAllAsRead = useCallback(() => {
     let previous: Notification[] = [];
     setNotifications((prev) => {
@@ -117,25 +112,21 @@ export const useNotifications = (): UseNotificationsReturn => {
       return prev.map((n) => ({ ...n, isRead: true }));
     });
 
-    // TODO: replace with `apiFetch('/notifications/read-all', { method: 'PATCH' })`
-    simulateRequest(null).catch(() => {
+    markAllNotificationsRead().catch((err: unknown) => {
+      if (err instanceof Error && err.name === 'AbortError') return;
       setNotifications(previous);
       setError('Failed to mark all notifications as read');
     });
   }, []);
 
+  /**
+   * Removes a notification from the local list.
+   *
+   * Local-only: the TrustUp API does not expose a delete endpoint (API-23/24).
+   * No server call is made. See JSDoc on `UseNotificationsReturn.deleteNotification`.
+   */
   const deleteNotification = useCallback((id: string) => {
-    let previous: Notification[] = [];
-    setNotifications((prev) => {
-      previous = prev;
-      return prev.filter((n) => n.id !== id);
-    });
-
-    // No delete endpoint is documented yet — this stays local-only for now.
-    simulateRequest(null).catch(() => {
-      setNotifications(previous);
-      setError('Failed to delete notification');
-    });
+    setNotifications((prev) => prev.filter((n) => n.id !== id));
   }, []);
 
   const unreadCount = notifications.reduce((count, n) => (n.isRead ? count : count + 1), 0);

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -48,7 +48,7 @@ function buildUrl(path: string, params?: RequestOptions['params']): string {
 }
 
 async function request<T>(
-  method: 'GET' | 'POST',
+  method: 'GET' | 'POST' | 'PATCH',
   path: string,
   body?: unknown,
   options?: RequestOptions
@@ -103,4 +103,6 @@ export const apiClient = {
   get: <T>(path: string, options?: RequestOptions) => request<T>('GET', path, undefined, options),
   post: <T>(path: string, body?: unknown, options?: RequestOptions) =>
     request<T>('POST', path, body, options),
+  patch: <T>(path: string, body?: unknown, options?: RequestOptions) =>
+    request<T>('PATCH', path, body, options),
 };

--- a/services/notifications.service.ts
+++ b/services/notifications.service.ts
@@ -1,0 +1,159 @@
+import { apiClient, isApiConfigured } from '../lib/api-client';
+import type { ApiNotificationsResponse, MarkAllReadResponse, MarkReadResponse } from '../types/api';
+import {
+  formatRelativeTime,
+  mapApiNotificationType,
+  type Notification,
+  type NotificationsResponse,
+} from '../types/Notification';
+
+// ─── Dev seeds ────────────────────────────────────────────────────────────────
+// Used ONLY when no API base URL is configured (`isApiConfigured === false`).
+// Shaped to the real backend DTO so the UI can be reviewed without a server.
+// MUST NOT be relied on in production.
+
+const DEV_API_NOTIFICATIONS: ApiNotificationsResponse = {
+  notifications: [
+    {
+      id: '1',
+      type: 'loan_reminder',
+      title: 'Payment Due Soon',
+      message: "Your $50.00 payment is due in 3 days. Don't miss it!",
+      isRead: false,
+      createdAt: new Date(Date.now() - 2 * 60 * 1000).toISOString(), // 2 min ago
+      data: { loanId: 'loan-123', amount: 50 },
+    },
+    {
+      id: '2',
+      type: 'credit_update',
+      title: 'Credit Increased',
+      message: 'Great news! Your available credit increased to $320.00.',
+      isRead: false,
+      createdAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(), // 1 hour ago
+    },
+    {
+      id: '3',
+      type: 'merchant_update',
+      title: 'New Merchant Available',
+      message: 'TechStore has joined TrustUp. Shop with BNPL now.',
+      isRead: false,
+      createdAt: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(), // 3 hours ago
+    },
+    {
+      id: '4',
+      type: 'reputation_update',
+      title: 'Reputation Updated',
+      message: 'Your reputation score improved to 82/100. Keep it up!',
+      isRead: true,
+      createdAt: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(), // yesterday
+    },
+    {
+      id: '5',
+      type: 'security',
+      title: 'Terms Updated',
+      message: "We've updated our privacy policy. Tap to review the changes.",
+      isRead: true,
+      createdAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(), // 3 days ago
+    },
+  ],
+  total: 5,
+  unreadCount: 3,
+  limit: 20,
+  offset: 0,
+};
+
+// ─── Mapping helper ───────────────────────────────────────────────────────────
+
+/**
+ * Converts a raw `ApiNotificationsResponse` into the UI-facing
+ * `NotificationsResponse`, mapping:
+ * - `message`   → `body`
+ * - `createdAt` → `timestamp` (human-relative string)
+ * - `type`      → UI bucket via `mapApiNotificationType`
+ */
+function mapApiResponse(raw: ApiNotificationsResponse): NotificationsResponse {
+  const notifications: Notification[] = raw.notifications.map((n) => ({
+    id: n.id,
+    type: mapApiNotificationType(n.type),
+    title: n.title,
+    body: n.message,
+    timestamp: formatRelativeTime(n.createdAt),
+    isRead: n.isRead,
+  }));
+  return { notifications, unreadCount: raw.unreadCount };
+}
+
+// ─── Service functions ────────────────────────────────────────────────────────
+
+export interface GetNotificationsParams {
+  unread?: boolean;
+  limit?: number;
+  offset?: number;
+  signal?: AbortSignal;
+}
+
+/**
+ * `GET /notifications` — paginated notifications for the authenticated user.
+ *
+ * Falls back to a named DEV seed when `EXPO_PUBLIC_API_URL` is not set
+ * (same `isApiConfigured` pattern as the loans and merchants services).
+ *
+ * NOTE: the backend endpoints are marked "Not Implemented" (API-23/24).
+ * The DEV seed ensures the UI can be developed and reviewed without a server.
+ */
+export async function getNotifications({
+  unread,
+  limit = 20,
+  offset = 0,
+  signal,
+}: GetNotificationsParams = {}): Promise<NotificationsResponse> {
+  if (!isApiConfigured) {
+    const seed = DEV_API_NOTIFICATIONS;
+    const filtered =
+      unread === true ? seed.notifications.filter((n) => !n.isRead) : seed.notifications;
+    const sliced = filtered.slice(offset, offset + limit);
+    const devRaw: ApiNotificationsResponse = {
+      notifications: sliced,
+      total: filtered.length,
+      unreadCount: seed.notifications.filter((n) => !n.isRead).length,
+      limit,
+      offset,
+    };
+    return mapApiResponse(devRaw);
+  }
+
+  const raw = await apiClient.get<ApiNotificationsResponse>('/notifications', {
+    params: { unread, limit, offset },
+    signal,
+  });
+  return mapApiResponse(raw);
+}
+
+/**
+ * `PATCH /notifications/:id/read` — mark a single notification as read.
+ *
+ * Returns `{ success: true }` on success.
+ * The caller (hook) is responsible for optimistic updates and rollback.
+ */
+export async function markNotificationRead(
+  id: string,
+  signal?: AbortSignal
+): Promise<MarkReadResponse> {
+  if (!isApiConfigured) {
+    return { success: true };
+  }
+  return apiClient.patch<MarkReadResponse>(`/notifications/${id}/read`, undefined, { signal });
+}
+
+/**
+ * `PATCH /notifications/read-all` — mark all notifications as read.
+ *
+ * Returns `{ success: true, updatedCount }` on success.
+ * The caller (hook) is responsible for optimistic updates and rollback.
+ */
+export async function markAllNotificationsRead(signal?: AbortSignal): Promise<MarkAllReadResponse> {
+  if (!isApiConfigured) {
+    return { success: true, updatedCount: 0 };
+  }
+  return apiClient.patch<MarkAllReadResponse>('/notifications/read-all', undefined, { signal });
+}

--- a/types/Notification.ts
+++ b/types/Notification.ts
@@ -1,16 +1,102 @@
-export type NotificationType = 'payment' | 'credit' | 'merchant' | 'reputation' | 'security';
+import type { ApiNotificationType } from './api';
 
+/**
+ * UI-facing notification type union.
+ *
+ * Maps backend snake_case type strings to the icon/colour buckets used by
+ * `NotificationsPanel`. New backend types fall through to the `'other'`
+ * bucket — `getIconConfig` handles it via its `default` case.
+ */
+export type NotificationType =
+  | 'payment'
+  | 'credit'
+  | 'merchant'
+  | 'reputation'
+  | 'security'
+  | 'other';
+
+/**
+ * Maps a raw backend `type` string to the UI `NotificationType` bucket.
+ *
+ * @example
+ *   mapApiNotificationType('loan_reminder')  // → 'payment'
+ *   mapApiNotificationType('credit_update')  // → 'credit'
+ */
+export function mapApiNotificationType(apiType: ApiNotificationType): NotificationType {
+  if (apiType === 'loan_reminder' || apiType === 'payment_due' || apiType === 'payment_received') {
+    return 'payment';
+  }
+  if (apiType === 'credit_update') return 'credit';
+  if (apiType === 'merchant_update') return 'merchant';
+  if (apiType === 'reputation_update') return 'reputation';
+  if (apiType === 'security') return 'security';
+  return 'other';
+}
+
+/**
+ * UI notification model consumed by `useNotifications`, `NotificationsPanel`,
+ * and `Header`.
+ *
+ * Field naming:
+ * - `body`      — display text (backend DTO uses `message`; the mapping
+ *                 happens in `notifications.service.ts`).
+ * - `timestamp` — human-readable relative string (e.g. "2 min ago");
+ *                 derived from the backend's ISO-8601 `createdAt`.
+ *
+ * Keeping `body` / `timestamp` here avoids changing every consumer; the
+ * service layer is responsible for the translation.
+ */
 export interface Notification {
   id: string;
+  /** UI bucket — mapped from the backend's snake_case `type` field. */
   type: NotificationType;
   title: string;
+  /** Display text, mapped from the backend `message` field. */
   body: string;
+  /** Human-readable relative time, derived from the backend `createdAt` ISO-8601 field. */
   timestamp: string;
   isRead: boolean;
 }
 
 /**
- * Response shape from `GET /notifications`.
+ * Formats an ISO-8601 timestamp into a human-readable relative string.
+ *
+ * Examples: "just now", "5 min ago", "2 hours ago", "Yesterday", "3 days ago",
+ * "1 Jan 2026".
+ */
+export function formatRelativeTime(isoTimestamp: string): string {
+  const now = Date.now();
+  let past: number;
+  try {
+    past = new Date(isoTimestamp).getTime();
+  } catch {
+    return isoTimestamp;
+  }
+  if (isNaN(past)) return isoTimestamp;
+
+  const diffMs = now - past;
+  const diffSec = Math.floor(diffMs / 1000);
+  const diffMin = Math.floor(diffSec / 60);
+  const diffHour = Math.floor(diffMin / 60);
+  const diffDay = Math.floor(diffHour / 24);
+
+  if (diffSec < 60) return 'just now';
+  if (diffMin < 60) return `${diffMin} min ago`;
+  if (diffHour < 24) return `${diffHour} hour${diffHour === 1 ? '' : 's'} ago`;
+  if (diffDay === 1) return 'Yesterday';
+  if (diffDay < 7) return `${diffDay} days ago`;
+
+  // Older than a week — show a short date
+  return new Date(past).toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+/**
+ * Response shape from `GET /notifications` as consumed by the hook (after
+ * mapping from the raw API response).
  */
 export interface NotificationsResponse {
   notifications: Notification[];

--- a/types/api.ts
+++ b/types/api.ts
@@ -139,3 +139,57 @@ export interface MerchantDetail {
   createdAt: string;
   updatedAt?: string;
 }
+
+// ─── Notifications ────────────────────────────────────────────────────────────
+
+/**
+ * Notification type values as returned by the backend.
+ * The API uses snake_case strings like "loan_reminder".
+ */
+export type ApiNotificationType =
+  | 'loan_reminder'
+  | 'payment_due'
+  | 'payment_received'
+  | 'credit_update'
+  | 'merchant_update'
+  | 'reputation_update'
+  | 'security'
+  | string; // allow future types without a type error
+
+/**
+ * One notification item as returned by `GET /notifications`.
+ * Field names match the backend DTO exactly.
+ */
+export interface ApiNotification {
+  id: string;
+  /** Snake_case type string (e.g. "loan_reminder"). */
+  type: ApiNotificationType;
+  title: string;
+  /** Body text — the backend field is named `message`, not `body`. */
+  message: string;
+  isRead: boolean;
+  /** ISO-8601 timestamp. */
+  createdAt: string;
+  /** Optional metadata (loanId, amount, etc). */
+  data?: Record<string, unknown>;
+}
+
+/** `GET /notifications` response — returned directly (no success envelope). */
+export interface ApiNotificationsResponse {
+  notifications: ApiNotification[];
+  total: number;
+  unreadCount: number;
+  limit: number;
+  offset: number;
+}
+
+/** `PATCH /notifications/:id/read` response. */
+export interface MarkReadResponse {
+  success: boolean;
+}
+
+/** `PATCH /notifications/read-all` response. */
+export interface MarkAllReadResponse {
+  success: boolean;
+  updatedCount: number;
+}


### PR DESCRIPTION
## 🔗 Related Issue
Closes #81

---

## 🔖 Title
feat: wire notifications hook to GET /notifications API

---

## 📝 Description
Replaces the five hardcoded `MOCK_NOTIFICATIONS` items and `simulateRequest` fake-latency in `hooks/notifications/use-notifications.ts` with real calls to the documented `GET /notifications`, `PATCH /notifications/:id/read`, and `PATCH /notifications/read-all` endpoints.

Because all three endpoints are currently marked **Not Implemented** (API-23/24) in the backend docs, the service layer follows the same `isApiConfigured` pattern already used by `loans.service.ts` and `merchants.service.ts`: when `EXPO_PUBLIC_API_URL` is not set, a clearly-named DEV seed (shaped to the real backend DTO) is returned instead. No production fake-success.

---

## 🔄 Changes Made
- [x] **`lib/api-client.ts`** — added `patch` method to `apiClient`; the PATCH endpoints require it and nothing in the codebase provided it before
- [x] **`types/api.ts`** — added `ApiNotificationType`, `ApiNotification`, `ApiNotificationsResponse`, `MarkReadResponse`, `MarkAllReadResponse` backend DTO types matching the documented endpoint shapes exactly
- [x] **`types/Notification.ts`** — added `mapApiNotificationType` (maps snake_case backend strings like `loan_reminder` to UI buckets), `formatRelativeTime` (ISO-8601 → human-relative string); `Notification` interface retains `body`/`timestamp` field names so `NotificationsPanel` and `Header` required zero changes
- [x] **`services/notifications.service.ts`** (new) — `getNotifications`, `markNotificationRead`, `markAllNotificationsRead`; all gated by `isApiConfigured` with DEV seeds
- [x] **`hooks/notifications/use-notifications.ts`** — removed all mocks and `simulateRequest`; calls service functions; optimistic `markAsRead`/`markAllAsRead` with rollback on failure; `deleteNotification` stays local-only (no delete endpoint in API, documented with JSDoc why); `AbortController` cancels in-flight requests on unmount/refresh

---

## ✅ Completed tasks from issue #81
- [x] Read TrustUp-API notification docs and `types/Notification.ts`
- [x] Add `services/notifications.service.ts` and switch the hook off mocks
- [x] Keep optimistic `markAsRead` / `markAllAsRead` with rollback
- [x] Leave delete local — commented why (no API endpoint documented)
- [x] No `any`; `tsc --noEmit` exits 0; lint 0 errors (7 pre-existing warnings in unrelated files)

**Scope out (per issue):** push notifications (OS), delete-on-server, panel redesign — none implemented.

---

## 📸 Screenshots (if applicable)
UI is unchanged — `NotificationsPanel` and `Header` consume the same hook interface (`notifications`, `unreadCount`, `isLoading`, `markAsRead`, `markAllAsRead`, `deleteNotification`). Loading skeleton, empty state, and error state are all preserved.

Manual regression path (per issue):
1. Open bell → list loads (DEV seed shows 5 items, 3 unread)
2. Mark one read → badge decreases by 1 (optimistic)
3. Mark all read → badge drops to 0
4. Delete an item → removed from list (local-only)
5. Simulated API failure → previous state restored, error surfaced

---

## 🗒️ Additional Notes
- The three notification endpoints are **Not Implemented** on the backend (API-23/24). When `EXPO_PUBLIC_API_URL` is configured and the server returns an error, the hook surfaces it via the `error` state already rendered by `NotificationsPanel`'s empty/error UI.
- `deleteNotification` intentionally makes no server call. The JSDoc on both the hook and the service explains this and notes what to do when a delete endpoint is added.
- The `patch` addition to `apiClient` is backward-compatible — no existing callers are affected.