### PR TITLE
feat(auth): refresh expired JWTs using stored refresh token (#80)

### DIFF
--- a/context/auth.context.tsx
+++ b/context/auth.context.tsx
@@ -1,5 +1,5 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
-import { apiFetch, ApiError, setUnauthorizedHandler } from '../lib/api';
+import { apiFetch, ApiError, setUnauthorizedHandler, setTokenChangeHandler } from '../lib/api';
 import { getAccessToken, setTokens, clearTokens } from '../lib/auth-storage';
 import { mapUserMeToProfile, type UserMeApiResponse, type UserProfile } from '../types/User';
 
@@ -89,6 +89,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     });
     return () => setUnauthorizedHandler(null);
   }, [signOut]);
+
+  // Keep state in sync when background refresh occurs
+  useEffect(() => {
+    setTokenChangeHandler((newToken: string) => {
+      setToken(newToken);
+    });
+    return () => setTokenChangeHandler(null);
+  }, []);
 
   const value = useMemo<AuthContextValue>(
     () => ({ user, token, isLoading, signIn, signOut, completeAuth }),

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -1,6 +1,8 @@
 import { getToken as getAccessToken, clearToken } from './token-storage';
 import { notifyUnauthorized } from './auth-events';
 import { FieldErrors } from './api';
+import { refreshAuthToken } from './auth-refresh';
+
 /**
  * Thin HTTP client for the TrustUp API.
  *
@@ -8,6 +10,7 @@ import { FieldErrors } from './api';
  *   with `/api/v1` appended automatically (per the frontend .env convention).
  * - Attaches the JWT Bearer token from `token-storage` when present.
  * - Throws `ApiClientError` on non-2xx with the backend's message when available.
+ * - On 401, attempts single-flight refresh with refresh token and retries once.
  *
  * NOTE: this is the pre-existing client for reputation/merchants/loans/pay.
  * The auth flow (#60) uses lib/api.ts instead. See lib/token-storage.ts for
@@ -51,7 +54,8 @@ async function request<T>(
   method: 'GET' | 'POST',
   path: string,
   body?: unknown,
-  options?: RequestOptions
+  options?: RequestOptions,
+  isRetry = false
 ): Promise<T> {
   const token = await getAccessToken();
   const headers: Record<string, string> = { Accept: 'application/json' };
@@ -72,6 +76,14 @@ async function request<T>(
   }
 
   if (res.status === 401) {
+    const isAuthEndpoint = path.startsWith('/auth/login') || path.startsWith('/auth/refresh');
+    if (!isRetry && !isAuthEndpoint) {
+      const refreshed = await refreshAuthToken(API_BASE_URL);
+      if (refreshed) {
+        return request<T>(method, path, body, options, true);
+      }
+    }
+
     await clearToken();
     notifyUnauthorized();
     throw new ApiClientError('Session expired. Please sign in again.', 401);

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,7 +1,8 @@
 import { getAccessToken, clearTokens } from './auth-storage';
 import { notifyUnauthorized, setUnauthorizedHandler } from './auth-events';
+import { refreshAuthToken, setTokenChangeHandler } from './auth-refresh';
 
-export { setUnauthorizedHandler };
+export { setUnauthorizedHandler, setTokenChangeHandler };
 
 export type FieldErrors = Record<string, string>;
 
@@ -88,6 +89,8 @@ export const unwrapApiData = <T>(body: unknown): T => {
 /**
  * Thin fetch wrapper that prefixes {@link API_BASE_URL}, attaches the stored
  * Bearer token, and parses JSON responses.
+ * If a 401 is encountered, it attempts a single token refresh using the stored refresh_token
+ * and retries the request once before signaling sign-out on failure.
  *
  * @param knownFields Optional list of form field names — when present, the
  *   error body is inspected for per-field validation errors (see
@@ -97,7 +100,8 @@ export const unwrapApiData = <T>(body: unknown): T => {
 export const apiFetch = async <T>(
   path: string,
   options: RequestInit = {},
-  knownFields?: string[]
+  knownFields?: string[],
+  isRetry = false
 ): Promise<T> => {
   const token = await getAccessToken();
 
@@ -117,6 +121,15 @@ export const apiFetch = async <T>(
   const response = await fetch(`${API_BASE_URL}${path}`, { ...options, headers });
 
   if (response.status === 401) {
+    // Avoid refresh loops on login/register/refresh itself
+    const isAuthEndpoint = path.startsWith('/auth/login') || path.startsWith('/auth/refresh');
+    if (!isRetry && !isAuthEndpoint) {
+      const refreshedToken = await refreshAuthToken(API_BASE_URL);
+      if (refreshedToken) {
+        return apiFetch<T>(path, options, knownFields, true);
+      }
+    }
+
     await clearTokens();
     notifyUnauthorized();
     throw new ApiError(401, 'Session expired. Please sign in again.');
@@ -158,7 +171,8 @@ export const apiFetch = async <T>(
 export const apiFetchForm = async <T>(
   path: string,
   formData: FormData,
-  knownFields?: string[]
+  knownFields?: string[],
+  isRetry = false
 ): Promise<T> => {
   const token = await getAccessToken();
   const headers: Record<string, string> = {};
@@ -175,6 +189,14 @@ export const apiFetchForm = async <T>(
   });
 
   if (response.status === 401) {
+    const isAuthEndpoint = path.startsWith('/auth/login') || path.startsWith('/auth/refresh');
+    if (!isRetry && !isAuthEndpoint) {
+      const refreshedToken = await refreshAuthToken(API_BASE_URL);
+      if (refreshedToken) {
+        return apiFetchForm<T>(path, formData, knownFields, true);
+      }
+    }
+
     await clearTokens();
     notifyUnauthorized();
     throw new ApiError(401, 'Session expired. Please sign in again.');

--- a/lib/auth-refresh.ts
+++ b/lib/auth-refresh.ts
@@ -1,0 +1,99 @@
+import { getRefreshToken, setTokens, clearTokens } from './auth-storage';
+import { notifyUnauthorized } from './auth-events';
+
+export interface RefreshResponse {
+  accessToken?: string;
+  access_token?: string;
+  refreshToken?: string;
+  refresh_token?: string;
+  expiresIn?: number;
+  expires_in?: number;
+}
+
+let inFlightRefresh: Promise<string | null> | null = null;
+let tokenChangeHandler: ((newToken: string) => void) | null = null;
+
+export const setTokenChangeHandler = (handler: ((newToken: string) => void) | null): void => {
+  tokenChangeHandler = handler;
+};
+
+export const notifyTokenChanged = (newToken: string): void => {
+  tokenChangeHandler?.(newToken);
+};
+
+/**
+ * Attempts a single in-flight token refresh using the stored refresh token.
+ * Returns the new access token on success, or null on failure (clearing tokens and notifying unauthorized).
+ */
+export async function refreshAuthToken(apiBaseUrl: string): Promise<string | null> {
+  if (inFlightRefresh) {
+    return inFlightRefresh;
+  }
+
+  inFlightRefresh = (async () => {
+    try {
+      const refreshToken = await getRefreshToken();
+      if (!refreshToken) {
+        await clearTokens();
+        notifyUnauthorized();
+        return null;
+      }
+
+      const cleanBase = (apiBaseUrl || '').replace(/\/+$/, '');
+      if (!cleanBase) {
+        await clearTokens();
+        notifyUnauthorized();
+        return null;
+      }
+
+      // If cleanBase already contains /api/v1 (e.g. from EXPO_PUBLIC_API_URL), use cleanBase + /auth/refresh
+      // Otherwise append /auth/refresh directly.
+      const url = `${cleanBase}/auth/refresh`;
+
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify({
+          refreshToken,
+          refresh_token: refreshToken,
+        }),
+      });
+
+      if (!response.ok) {
+        await clearTokens();
+        notifyUnauthorized();
+        return null;
+      }
+
+      const json = (await response.json()) as RefreshResponse | { data?: RefreshResponse };
+      const data: RefreshResponse =
+        json && typeof json === 'object' && 'data' in json && json.data
+          ? json.data
+          : (json as RefreshResponse);
+
+      const newAccessToken = data.accessToken || data.access_token;
+      const newRefreshToken = data.refreshToken || data.refresh_token || refreshToken;
+
+      if (!newAccessToken) {
+        await clearTokens();
+        notifyUnauthorized();
+        return null;
+      }
+
+      await setTokens(newAccessToken, newRefreshToken);
+      notifyTokenChanged(newAccessToken);
+      return newAccessToken;
+    } catch {
+      await clearTokens();
+      notifyUnauthorized();
+      return null;
+    } finally {
+      inFlightRefresh = null;
+    }
+  })();
+
+  return inFlightRefresh;
+}


### PR DESCRIPTION
## 🔗 Related Issue
Closes #80

---

## 🔖 Title
Refresh expired JWTs using the stored refresh token

---

## 📝 Description
Implements automatic, transparent JWT refresh on HTTP 401 using the stored refresh token per the TrustUp API specification (`POST /auth/refresh`). 
Previously, expired access tokens caused immediate token clearance and forced the user to the Sign In screen even when a valid refresh token existed. With this change, both `apiFetch` (`lib/api.ts`) and `apiClient` (`lib/api-client.ts`) attempt a single-flight background refresh, update the stored tokens, sync the `AuthProvider` session state, and retry the failed request once before falling back to sign-out.

---

## 🔄 Changes Made
- [x] Implemented `lib/auth-refresh.ts` with single-flight mutex refresh logic to prevent concurrent 401 request stampedes.
- [x] Aligned refresh payload and parsing with `POST /auth/refresh` specification in TrustUp-API docs (supporting `refreshToken` / `refresh_token` and camelCase/snake_case token responses).
- [x] Updated `apiFetch` and `apiFetchForm` in `lib/api.ts` to refresh and retry on 401 status while avoiding loops on auth endpoints.
- [x] Updated `request` in `lib/api-client.ts` to refresh and retry on 401 status.
- [x] Added token change notification listener in `context/auth.context.tsx` to keep React state in sync upon token rotation.
- [x] Maintained fallback to `clearTokens()` / `clearToken()` and `notifyUnauthorized()` when refresh fails or refresh token is missing/invalid.

---

## 📸 Screenshots (if applicable)
N/A (HTTP client and authentication middleware enhancement)

---

## 🗒️ Additional Notes
- Verified with TypeScript type checking (`npx tsc --noEmit`) and ESLint.
- No tokens are logged.