### PR TITLE
feat(pages): show PayScreen as authenticated home screen (#72)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 import { View, ActivityIndicator, StatusBar } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import InvestScreen from 'components/pages/InvestScreen';
+import PayScreen from 'components/pages/pay/PayScreen';
 import SignInScreen from 'components/pages/SignIn';
 import CreateAccountScreen from 'components/pages/CreateAccountScreen';
 import { MainLayout } from 'components/shared/MainLayout';
@@ -47,7 +47,7 @@ function AppContent() {
 
   return (
     <MainLayout onSignOut={handleSignOut}>
-      <InvestScreen />
+      <PayScreen />
     </MainLayout>
   );
 }


### PR DESCRIPTION
## 🔗 Related Issue
Closes #72

---

## 🔖 Title
feat(pages): show PayScreen as authenticated home screen

---

## 📝 Description
Swaps the authenticated child component inside `App.tsx` from `InvestScreen` to `PayScreen`, making the BNPL home the default landing view upon user sign-in. This enables authenticated users to immediately see their reputation score, credit limits, active loans, and payment status, while maintaining all callback integrations (`onLoanHistoryPress`, `onViewReputationPress`, `onExploreMerchantsPress`, and `onToast`) injected via `MainLayout`. `InvestScreen` is retained in the codebase for future tab integration.

---

## 🔄 Changes Made
- [x] Imported `PayScreen` from `components/pages/pay/PayScreen` in `App.tsx`
- [x] Swapped `<InvestScreen />` with `<PayScreen />` inside `<MainLayout>` in `AppContent`
- [x] Preserved `InvestScreen` component in the repository for upcoming tab routing
- [x] Validated TypeScript compilation (`npx tsc --noEmit`) without errors

---

## 📸 Screenshots (if applicable)
N/A (Root component swap verified via TypeScript compilation and props alignment)

---

## 🗒️ Additional Notes
- No overlay or BottomBar refactoring was introduced in this PR.
- Callbacks injected by `MainLayout` cloneElement are properly received by `PayScreenProps`.
