### PR TITLE
feat(loans): replace mock loan list in useLoans with GET /loans/my-loans (#75)

### DIFF
--- a/components/pages/LoanDetailScreen.tsx
+++ b/components/pages/LoanDetailScreen.tsx
@@ -330,16 +330,18 @@ const LoanDetailScreen: React.FC<LoanDetailScreenProps> = ({ loan, onBack }) => 
         )}
 
         {/* Payment Timeline */}
-        <View className="mb-4 rounded-2xl bg-white p-6 shadow-sm">
-          <Text className="mb-4 text-base font-bold text-textStrong">Payment Timeline</Text>
-          {loan.installments.map((installment, index) => (
-            <TimelineItem
-              key={installment.id}
-              installment={installment}
-              isLast={index === loan.installments.length - 1}
-            />
-          ))}
-        </View>
+        {loan.installments && loan.installments.length > 0 ? (
+          <View className="mb-4 rounded-2xl bg-white p-6 shadow-sm">
+            <Text className="mb-4 text-base font-bold text-textStrong">Payment Timeline</Text>
+            {loan.installments.map((installment, index) => (
+              <TimelineItem
+                key={installment.id}
+                installment={installment}
+                isLast={index === loan.installments.length - 1}
+              />
+            ))}
+          </View>
+        ) : null}
 
         {/* Loan Details Card */}
         <View className="rounded-2xl bg-white p-6 shadow-sm">

--- a/hooks/loans/use-loans.test.ts
+++ b/hooks/loans/use-loans.test.ts
@@ -4,8 +4,10 @@ import {
   formatLoanAmount,
   getDueDateLabel,
   hasOverdueInstallments,
+  mapLoanListItemToLoan,
 } from './use-loans';
 import type { Loan } from '../../types/Loan';
+import type { LoanListItem } from '../../types/api';
 
 // ─── Shared fixtures ──────────────────────────────────────────────────────────
 
@@ -30,6 +32,72 @@ const makeLoan = (overrides: Partial<Loan>): Loan => ({
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe('useLoans utility functions', () => {
+  describe('mapLoanListItemToLoan', () => {
+    it('maps backend LoanListItem DTO correctly to frontend Loan model', () => {
+      const dto: LoanListItem = {
+        id: 'dto-id-1',
+        loanId: 'chain-1',
+        amount: 500,
+        loanAmount: 400,
+        guarantee: 100,
+        interestRate: 8,
+        totalRepayment: 410.67,
+        totalPaid: 205.34,
+        remainingBalance: 205.33,
+        term: 4,
+        status: 'active',
+        merchant: { id: 'm-1', name: 'TechStore', logo: null },
+        nextPayment: { dueDate: '2026-07-20T00:00:00.000Z', amount: 102.66 },
+        createdAt: '2026-03-29T12:00:00.000Z',
+        completedAt: null,
+        defaultedAt: null,
+      };
+
+      const loan = mapLoanListItemToLoan(dto);
+      expect(loan.id).toBe('dto-id-1');
+      expect(loan.merchantName).toBe('TechStore');
+      expect(loan.merchantId).toBe('m-1');
+      expect(loan.amount).toBe(500);
+      expect(loan.amountPaid).toBe(205.34);
+      expect(loan.interestRate).toBe(8);
+      expect(loan.totalWithInterest).toBe(410.67);
+      expect(loan.status).toBe('active');
+      expect(loan.installmentCount).toBe(4);
+      expect(loan.installments).toEqual([]);
+      expect(loan.nextPaymentDue).toBe('2026-07-20T00:00:00.000Z');
+      expect(loan.nextPaymentAmount).toBe(102.66);
+      expect(loan.createdAt).toBe('2026-03-29T12:00:00.000Z');
+      expect(loan.completedAt).toBeNull();
+    });
+
+    it('handles missing merchant or nextPayment safely', () => {
+      const dto: LoanListItem = {
+        id: 'dto-id-2',
+        loanId: 'chain-2',
+        amount: 300,
+        loanAmount: 300,
+        guarantee: 0,
+        interestRate: 5,
+        totalRepayment: 315,
+        totalPaid: 315,
+        remainingBalance: 0,
+        term: 2,
+        status: 'completed',
+        merchant: { id: null, name: null, logo: null },
+        nextPayment: { dueDate: null, amount: null },
+        createdAt: '2026-01-01T00:00:00.000Z',
+        completedAt: '2026-02-01T00:00:00.000Z',
+        defaultedAt: null,
+      };
+
+      const loan = mapLoanListItemToLoan(dto);
+      expect(loan.merchantName).toBe('Unknown Merchant');
+      expect(loan.nextPaymentDue).toBeNull();
+      expect(loan.nextPaymentAmount).toBeNull();
+      expect(loan.completedAt).toBe('2026-02-01T00:00:00.000Z');
+    });
+  });
+
   describe('filterLoansByStatus', () => {
     const loans: Loan[] = [
       makeLoan({ id: '1', status: 'active' }),
@@ -176,9 +244,14 @@ describe('useLoans utility functions', () => {
       expect(hasOverdueInstallments(loan)).toBe(false);
     });
 
-    it('returns false for an empty installments array', () => {
-      const loan = makeLoan({ installments: [] });
+    it('returns false for an empty installments array when active and not past due', () => {
+      const loan = makeLoan({ installments: [], status: 'active', nextPaymentDue: '2099-01-01' });
       expect(hasOverdueInstallments(loan)).toBe(false);
+    });
+
+    it('returns true for an empty installments array when defaulted', () => {
+      const loan = makeLoan({ installments: [], status: 'defaulted' });
+      expect(hasOverdueInstallments(loan)).toBe(true);
     });
   });
 });

--- a/hooks/loans/use-loans.ts
+++ b/hooks/loans/use-loans.ts
@@ -1,200 +1,31 @@
 import { useState, useCallback } from 'react';
 import type { Loan, LoanStatus } from '../../types/Loan';
+import type { LoanListItem } from '../../types/api';
+import { getMyLoans } from '../../services/loans.service';
 
-// ─── Mock Data ────────────────────────────────────────────────────────────────
+// ─── Utilities & Mappers ──────────────────────────────────────────────────────
 
-const MOCK_LOANS: Loan[] = [
-  {
-    id: 'loan-001',
-    merchantName: 'TechStore',
-    merchantId: 'merchant-001',
-    amount: 150.0,
-    amountPaid: 50.0,
-    interestRate: 3.5,
-    totalWithInterest: 155.25,
-    status: 'active',
-    installmentCount: 3,
-    installments: [
-      {
-        id: 'inst-001',
-        installmentNumber: 1,
-        amount: 51.75,
-        dueDate: '2026-06-01',
-        paidDate: '2026-05-30',
-        status: 'paid',
-      },
-      {
-        id: 'inst-002',
-        installmentNumber: 2,
-        amount: 51.75,
-        dueDate: '2026-07-01',
-        paidDate: null,
-        status: 'pending',
-      },
-      {
-        id: 'inst-003',
-        installmentNumber: 3,
-        amount: 51.75,
-        dueDate: '2026-08-01',
-        paidDate: null,
-        status: 'pending',
-      },
-    ],
-    nextPaymentDue: '2026-07-01',
-    nextPaymentAmount: 51.75,
-    createdAt: '2026-05-15T10:30:00Z',
-    completedAt: null,
-  },
-  {
-    id: 'loan-002',
-    merchantName: 'FashionHub',
-    merchantId: 'merchant-002',
-    amount: 280.0,
-    amountPaid: 96.6,
-    interestRate: 4.0,
-    totalWithInterest: 291.2,
-    status: 'active',
-    installmentCount: 4,
-    installments: [
-      {
-        id: 'inst-004',
-        installmentNumber: 1,
-        amount: 72.8,
-        dueDate: '2026-05-15',
-        paidDate: '2026-05-14',
-        status: 'paid',
-      },
-      {
-        id: 'inst-005',
-        installmentNumber: 2,
-        amount: 72.8,
-        dueDate: '2026-06-15',
-        paidDate: '2026-06-13',
-        status: 'paid',
-      },
-      {
-        id: 'inst-006',
-        installmentNumber: 3,
-        amount: 72.8,
-        dueDate: '2026-06-24',
-        paidDate: null,
-        status: 'overdue',
-      },
-      {
-        id: 'inst-007',
-        installmentNumber: 4,
-        amount: 72.8,
-        dueDate: '2026-08-15',
-        paidDate: null,
-        status: 'pending',
-      },
-    ],
-    nextPaymentDue: '2026-06-24',
-    nextPaymentAmount: 72.8,
-    createdAt: '2026-04-20T08:00:00Z',
-    completedAt: null,
-  },
-  {
-    id: 'loan-003',
-    merchantName: 'ElectroMart',
-    merchantId: 'merchant-003',
-    amount: 500.0,
-    amountPaid: 500.0,
-    interestRate: 2.5,
-    totalWithInterest: 512.5,
-    status: 'completed',
-    installmentCount: 5,
-    installments: [
-      {
-        id: 'inst-008',
-        installmentNumber: 1,
-        amount: 102.5,
-        dueDate: '2026-01-15',
-        paidDate: '2026-01-14',
-        status: 'paid',
-      },
-      {
-        id: 'inst-009',
-        installmentNumber: 2,
-        amount: 102.5,
-        dueDate: '2026-02-15',
-        paidDate: '2026-02-15',
-        status: 'paid',
-      },
-      {
-        id: 'inst-010',
-        installmentNumber: 3,
-        amount: 102.5,
-        dueDate: '2026-03-15',
-        paidDate: '2026-03-12',
-        status: 'paid',
-      },
-      {
-        id: 'inst-011',
-        installmentNumber: 4,
-        amount: 102.5,
-        dueDate: '2026-04-15',
-        paidDate: '2026-04-14',
-        status: 'paid',
-      },
-      {
-        id: 'inst-012',
-        installmentNumber: 5,
-        amount: 102.5,
-        dueDate: '2026-05-15',
-        paidDate: '2026-05-10',
-        status: 'paid',
-      },
-    ],
-    nextPaymentDue: null,
-    nextPaymentAmount: null,
-    createdAt: '2025-12-20T14:00:00Z',
-    completedAt: '2026-05-10T09:30:00Z',
-  },
-  {
-    id: 'loan-004',
-    merchantName: 'HomeGoods',
-    merchantId: 'merchant-004',
-    amount: 200.0,
-    amountPaid: 68.0,
-    interestRate: 5.0,
-    totalWithInterest: 210.0,
-    status: 'defaulted',
-    installmentCount: 3,
-    installments: [
-      {
-        id: 'inst-013',
-        installmentNumber: 1,
-        amount: 70.0,
-        dueDate: '2026-02-01',
-        paidDate: '2026-02-01',
-        status: 'paid',
-      },
-      {
-        id: 'inst-014',
-        installmentNumber: 2,
-        amount: 70.0,
-        dueDate: '2026-03-01',
-        paidDate: null,
-        status: 'overdue',
-      },
-      {
-        id: 'inst-015',
-        installmentNumber: 3,
-        amount: 70.0,
-        dueDate: '2026-04-01',
-        paidDate: null,
-        status: 'overdue',
-      },
-    ],
-    nextPaymentDue: null,
-    nextPaymentAmount: null,
-    createdAt: '2026-01-10T12:00:00Z',
-    completedAt: null,
-  },
-];
-
-// ─── Utilities ────────────────────────────────────────────────────────────────
+/**
+ * Maps a backend `LoanListItem` DTO to the frontend `Loan` UI model.
+ */
+export const mapLoanListItemToLoan = (item: LoanListItem): Loan => {
+  return {
+    id: item.id || item.loanId,
+    merchantName: item.merchant?.name || 'Unknown Merchant',
+    merchantId: item.merchant?.id || '',
+    amount: item.amount ?? item.loanAmount ?? 0,
+    amountPaid: item.totalPaid ?? 0,
+    interestRate: item.interestRate ?? 0,
+    totalWithInterest: item.totalRepayment ?? item.amount ?? item.loanAmount ?? 0,
+    status: item.status,
+    installmentCount: item.term ?? 0,
+    installments: [],
+    nextPaymentDue: item.nextPayment?.dueDate ?? null,
+    nextPaymentAmount: item.nextPayment?.amount ?? null,
+    createdAt: item.createdAt,
+    completedAt: item.completedAt ?? null,
+  };
+};
 
 /**
  * Filters a list of loans by their status.
@@ -246,6 +77,15 @@ export const getDueDateLabel = (dueDateStr: string): string => {
  * Checks whether any installment in a loan is overdue.
  */
 export const hasOverdueInstallments = (loan: Loan): boolean => {
+  if (!loan.installments || loan.installments.length === 0) {
+    if (loan.status === 'defaulted') return true;
+    if (loan.nextPaymentDue && loan.status === 'active') {
+      const now = new Date();
+      const dueDate = new Date(loan.nextPaymentDue);
+      return dueDate.getTime() < now.getTime();
+    }
+    return false;
+  }
   return loan.installments.some((inst) => inst.status === 'overdue');
 };
 
@@ -268,7 +108,7 @@ export interface UseLoansReturn {
 const PAGE_SIZE = 20;
 
 /**
- * Custom hook for fetching and managing the user's loan list.
+ * Custom hook for fetching and managing the user's loan list via getMyLoans.
  * Supports status filtering and pagination.
  */
 export const useLoans = (): UseLoansReturn => {
@@ -280,41 +120,44 @@ export const useLoans = (): UseLoansReturn => {
   const [offset, setOffset] = useState(0);
 
   /**
-   * Fetches loans from the API.
-   *
-   * @todo Replace this placeholder implementation with a real network call:
-   *   GET /loans/my-loans?status={status}&limit={limit}&offset={offset}
-   *
-   * Until the endpoint is available this function returns hardcoded mock data
-   * so that the UI can be developed and reviewed. It MUST NOT ship to
-   * production in this state.
+   * Fetches loans from getMyLoans service.
    */
-  const fetchLoans = useCallback((status: LoanStatus, pageOffset: number, append: boolean) => {
-    setIsLoading(true);
-    setError(null);
+  const fetchLoans = useCallback(
+    async (status: LoanStatus, pageOffset: number, append: boolean) => {
+      setIsLoading(true);
+      setError(null);
 
-    // TODO: replace with `fetch('/loans/my-loans?...')` once the API is ready.
-    setTimeout(() => {
       try {
-        const filtered = filterLoansByStatus(MOCK_LOANS, status);
-        const page = filtered.slice(pageOffset, pageOffset + PAGE_SIZE);
+        const response = await getMyLoans({
+          status: status === 'pending' ? undefined : status,
+          limit: PAGE_SIZE,
+          offset: pageOffset,
+        });
+
+        const mappedLoans = (response.data || []).map(mapLoanListItemToLoan);
+        // If the backend returns all loans or unfiltered status when 'pending' was passed, filter locally
+        const filteredLoans =
+          status === 'pending' ? mappedLoans.filter((l) => l.status === 'pending') : mappedLoans;
 
         if (append) {
-          setLoans((prev) => [...prev, ...page]);
+          setLoans((prev) => [...prev, ...filteredLoans]);
         } else {
-          setLoans(page);
+          setLoans(filteredLoans);
         }
 
-        setHasMore(pageOffset + PAGE_SIZE < filtered.length);
-        setOffset(pageOffset + PAGE_SIZE);
+        const total = response.pagination?.total ?? filteredLoans.length;
+        const currentCount = pageOffset + filteredLoans.length;
+        setHasMore(currentCount < total);
+        setOffset(pageOffset + filteredLoans.length);
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Failed to load loans';
         setError(message);
       } finally {
         setIsLoading(false);
       }
-    }, 600);
-  }, []);
+    },
+    []
+  );
 
   // Change the active status filter and re-fetch from the beginning
   const setActiveFilter = useCallback(


### PR DESCRIPTION
## 🔗 Related Issue
Closes #75

---

## 🔖 Title
Replace mock loan list in useLoans with GET /loans/my-loans

---

## 📝 Description
Replaced the hardcoded  array and artificial  in  with real API calls through  (). Added DTO mapping from backend  to UI  model, preserving status filtering, pagination (), and DEV seeds fallback when API URL is not set. Updated  to conditionally render the payment timeline and updated unit tests in  to cover DTO mapping and status assertions.

---

## 🔄 Changes Made
- [x] Read , ,  and contributing guidelines
- [x] Connected  hook to  with , , 
- [x] Added  utility to translate backend  to frontend 
- [x] Handled missing installment data cleanly in  (conditionally rendered timeline)
- [x] Extended and updated  test suite
- [x] Confirmed TypeScript passes with zero errors without any  types
- [x] Tested status tabs, pull/scroll load-more, empty/error/loading states

---

## 📸 Screenshots (if applicable)
_N/A - Functional API hook and data mapping update; UI layout preserved._

---

## 🗒️ Additional Notes
Maintains consistency with the existing DEV seed in  when running offline or without an active API URL.
