### PR TITLE
Rebrand Expo app as TrustUp

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
-    "name": "my-expo-app",
-    "slug": "my-expo-app",
+    "name": "TrustUp",
+    "slug": "TrustUp",
     "version": "1.0.0",
     "web": {
       "favicon": "./assets/favicon.png"


### PR DESCRIPTION
## 🔗 Related Issue
Closes #78

---

## 🔖 Title
Rebrand Expo app from my-expo-app to TrustUp

---

## 📝 Description
Updates the Expo application identity to use the TrustUp product name. This ensures Expo Go, device home screens, and future Expo builds display the correct application name.

---

## 🔄 Changes Made
- [x] Updated `expo.name` from `my-expo-app` to `TrustUp`.
- [x] Updated `expo.slug` from `my-expo-app` to `TrustUp`.
- [x] Preserved version `1.0.0` and all existing splash and icon paths.
- [x] Confirmed Expo starts successfully and displays `TrustUp`.
- [x] Confirmed the splash and icon files still exist at their configured paths.

---

## 📸 Screenshots (if applicable)
Not applicable. This change only updates Expo application metadata and does not modify the in-app UI.

Test evidence:
- `npm start` starts Expo/Metro successfully.
- Expo serves the application with the title `TrustUp`.
- The web bundle compiles successfully.

---

## 🗒️ Additional Notes
Only `app.json` was modified.

`npm run lint` currently encounters pre-existing undefined references for `ProfileScreen` and `EditProfileScreen` in `components/shared/MainLayout.tsx`. These are unrelated to the Expo configuration change and were left untouched to preserve the requested scope.