### PR TITLE
Fix TypeScript path aliases and contributing project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,17 +60,19 @@ TrustUp-Frontend/
 ├── .expo/                      # Expo configuration cache
 ├── assets/                     # Static assets (images, fonts)
 ├── components/                 # Reusable UI components
-│   ├── shared/                # Shared components across app
-│   │   ├── BottomBar.tsx     # Bottom navigation bar
-│   │   ├── Header.tsx        # App header component
-│   │   ├── MainLayout.tsx    # Main app layout wrapper
-├── pages/                      # Screen pages
-│   ├── InvestScreen/          # Investment screen
-│   │   ├── components/       # InvestScreen-specific components
-│   │   └── InvestScreen.tsx  # Main invest screen
-│   └── PayScreen/             # Payment screen
-│       ├── components/       # PayScreen-specific components
-│       └── PayScreen.tsx     # Main payment screen
+│   ├── pages/                 # Screen components
+│   │   ├── InvestScreen/     # Investment screen
+│   │   ├── SignIn/           # Sign in screen
+│   │   └── CreateAccountScreen/ # Create account screen
+│   └── shared/                # Shared components across app
+│       ├── BottomBar.tsx     # Bottom navigation bar
+│       ├── Header.tsx        # App header component
+│       └── MainLayout.tsx    # Main app layout wrapper
+├── context/                    # React context providers (e.g. auth)
+├── hooks/                      # Domain-specific custom hooks
+├── lib/                        # API client, storage, and other utilities
+├── services/                   # API service modules
+├── theme/                      # Design tokens (colors, etc.)
 ├── types/                      # TypeScript type definitions
 ├── node_modules/              # Dependencies
 ├── .gitignore                 # Git ignore rules

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -158,12 +158,19 @@ npm run web
 
 - `App.tsx` - Application entry point
 - `components/` - Reusable UI components
+  - `pages/` - Screen components (e.g. `InvestScreen/`, `SignIn/`, `CreateAccountScreen/`)
   - `shared/` - Shared components (Layout, Navigation, etc.)
-- `pages/` - Screen components
-  - `InvestScreen/` - Investment flow screens
-  - `PayScreen/` - Payment flow screens
+- `hooks/` - Domain-specific custom hooks
+- `services/` - API service modules
+- `lib/` - API client, storage, and other utilities
+- `context/` - React context providers (e.g. auth)
 - `types/` - TypeScript type definitions
+- `theme/` - Design tokens (colors, etc.)
 - `assets/` - Images, fonts, and static resources
+
+### Import Aliases
+
+The `@/*` path alias resolves to the repository root (`tsconfig.json` sets `baseUrl: "."` and `"@/*": ["./*"]`), so `@/types/Loan` resolves to `types/Loan.ts`. You can also use plain relative/root imports (e.g. `components/pages/InvestScreen`) since `baseUrl` is set to the project root.
 
 ### Creating New Components
 
@@ -200,7 +207,7 @@ npm run web
 
 1. Create screen directory and component:
 ```typescript
-   // pages/ProfileScreen/ProfileScreen.tsx
+   // components/pages/ProfileScreen/ProfileScreen.tsx
    import React from 'react';
    import { View, Text } from 'react-native';
    
@@ -215,7 +222,7 @@ npm run web
 
 2. Add screen-specific components in subdirectory:
 ```
-   pages/ProfileScreen/
+   components/pages/ProfileScreen/
    ├── ProfileScreen.tsx
    └── components/
        ├── ProfileHeader.tsx
@@ -322,13 +329,14 @@ This creates `ios/` and `android/` directories for advanced customization.
 ### File Organization
 ```
 components/
-├── shared/           # Reusable across entire app
+├── shared/               # Reusable across entire app
 │   ├── Button.tsx
 │   └── Input.tsx
-└── LoanScreen/           # Domain-specific components
-    └── LoanScreen.tsx
-    ├── components.tsx
-    └── LoanCard.tsx
+└── pages/
+    └── LoanScreen/       # Domain-specific screen
+        ├── LoanScreen.tsx
+        └── components/
+            └── LoanCard.tsx
 ```
 
 ### TypeScript

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "expo-clipboard": "~8.0.8",
     "expo-constants": "~18.0.13",
     "expo-image-picker": "^17.0.10",
-    "expo-router": "^6.0.21",
     "expo-secure-store": "~15.0.8",
     "expo-status-bar": "~3.0.8",
     "lucide-react-native": "^0.562.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "baseUrl": ".",
     "jsx": "react-native",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./*"]
     },
     "types": ["jest"]
   }


### PR DESCRIPTION
## 🔗 Related Issue
Closes #79

---

## 🔖 Title
Fix TypeScript path aliases and contributing project structure

---

## 📝 Description
`tsconfig.json` mapped `@/*` to a nonexistent `src/*` directory, so any `@/...` import (like the ones shown in `docs/contributing.md`) would fail to resolve. Meanwhile the README and contributing guide described screens as living under `pages/`, but they actually live under `components/pages/`, and `expo-router` was listed as a dependency despite not being used anywhere in the app (`App.tsx` is the real entry point).

This PR:
- Fixes the `@/*` alias to point at the repo root (`baseUrl: "."` + `"@/*": ["./*"]`) so it resolves against the real top-level folders (`components`, `hooks`, `lib`, `types`, `services`, `context`, `theme`) instead of a folder that doesn't exist.
- Updates `README.md`'s Project Structure tree to reflect the actual layout (`components/pages`, `hooks`, `services`, `lib`, `context`, `theme`).
- Updates `docs/contributing.md`'s Project Structure list, "Creating New Screens" example, and File Organization example to use `components/pages/...` instead of the nonexistent top-level `pages/...`, and documents how the `@/*` alias resolves.
- Removes the unused `expo-router` dependency from `package.json` (confirmed zero imports/usages across the codebase and config files).

**Scope out (per issue):** No migration to Expo Router, no introduction of a `src/` directory — docs/tsconfig changes only.

**Regression:** `baseUrl: "."` was left unchanged, so existing relative/root imports like `components/pages/InvestScreen` continue to compile exactly as before.

---

## 🔄 Changes Made
- [x] Fixed `@/*` path alias in `tsconfig.json` to resolve against the real project root instead of nonexistent `src/`
- [x] Updated `README.md` Project Structure section to list `components/pages`, `hooks`, `services`, `lib`, `context`, `theme`
- [x] Updated `docs/contributing.md` Project Structure, screen-creation example, and file organization example to use `components/pages/...`
- [x] Removed unused `expo-router` dependency from `package.json` (grep confirmed zero usage)

---

## 📸 Screenshots (if applicable)
Not applicable — this PR only touches `tsconfig.json`, `package.json`, and documentation (`README.md`, `docs/contributing.md`). No UI changes.

---

## 🗒️ Additional Notes
- Per the issue scope, this does not move any files into a `src/` directory and does not migrate the app to Expo Router.
- `npx tsc --noEmit` and `npm run lint` were not run in this environment; reviewers should confirm both pass before merging.

Closes #79